### PR TITLE
Implement pivot operation for EAV/measurement data transformation

### DIFF
--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -255,6 +255,7 @@ class ClassDerivation(ElementDerivation):
     target_definition: Optional[Any] = Field(default=None, description="""LinkML class definition object for this slot.""", json_schema_extra = { "linkml_meta": {'alias': 'target_definition',
          'comments': ['currently defined as Any to avoid coupling with metamodel'],
          'domain_of': ['ClassDerivation', 'SlotDerivation']} })
+    pivot_operation: Optional[PivotOperation] = Field(default=None, description="""Configuration for pivot (unmelt) operations at class level""", json_schema_extra = { "linkml_meta": {'alias': 'pivot_operation', 'domain_of': ['ClassDerivation', 'SlotDerivation']} })
     name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'alias': 'name',
          'domain_of': ['ElementDerivation',
                        'ObjectDerivation',
@@ -371,6 +372,7 @@ class SlotDerivation(ElementDerivation):
     dictionary_key: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'dictionary_key', 'domain_of': ['SlotDerivation']} })
     stringification: Optional[StringificationConfiguration] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'stringification', 'domain_of': ['SlotDerivation']} })
     aggregation_operation: Optional[AggregationOperation] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'aggregation_operation', 'domain_of': ['SlotDerivation']} })
+    pivot_operation: Optional[PivotOperation] = Field(default=None, description="""Configuration for pivot (melt) operations producing this slot""", json_schema_extra = { "linkml_meta": {'alias': 'pivot_operation', 'domain_of': ['ClassDerivation', 'SlotDerivation']} })
     copy_directives: Optional[Dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'alias': 'copy_directives',
          'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'alias': 'overrides', 'domain_of': ['ElementDerivation']} })
@@ -605,6 +607,12 @@ class PivotOperation(TransformationOperation):
          'ifabsent': 'string(value)'} })
     unmelt_to_class: Optional[str] = Field(default=None, description="""In an unmelt operation, attributes (which are values in the long/melted/EAV representation) must conform to valid attributes in this class""", json_schema_extra = { "linkml_meta": {'alias': 'unmelt_to_class', 'domain_of': ['PivotOperation']} })
     unmelt_to_slots: Optional[List[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'alias': 'unmelt_to_slots', 'domain_of': ['PivotOperation']} })
+    unit_slot: Optional[str] = Field(default=None, description="""Optional slot containing unit information for {variable}_{unit} naming""", json_schema_extra = { "linkml_meta": {'alias': 'unit_slot', 'domain_of': ['PivotOperation']} })
+    slot_name_template: Optional[str] = Field(default="{variable}", description="""Template for generating target slot names. Supports {variable} and {unit}.""", json_schema_extra = { "linkml_meta": {'alias': 'slot_name_template',
+         'domain_of': ['PivotOperation'],
+         'ifabsent': 'string({variable})'} })
+    source_slots: Optional[List[str]] = Field(default_factory=list, description="""For MELT, the list of wide-format slots to melt""", json_schema_extra = { "linkml_meta": {'alias': 'source_slots', 'domain_of': ['PivotOperation']} })
+    id_slots: Optional[List[str]] = Field(default_factory=list, description="""Slots that identify the entity (not pivoted)""", json_schema_extra = { "linkml_meta": {'alias': 'id_slots', 'domain_of': ['PivotOperation']} })
 
 
 class KeyVal(ConfiguredBaseModel):

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -195,6 +195,9 @@ classes:
           LinkML class definition object for this slot.
         comments:
           - currently defined as Any to avoid coupling with metamodel
+      pivot_operation:
+        range: PivotOperation
+        description: Configuration for pivot (unmelt) operations at class level
 
   ObjectDerivation:
     is_a: ElementDerivation
@@ -283,6 +286,9 @@ classes:
         range: StringificationConfiguration
       aggregation_operation:
         range: AggregationOperation
+      pivot_operation:
+        range: PivotOperation
+        description: Configuration for pivot (melt) operations producing this slot
 
   EnumDerivation:
     is_a: ElementDerivation
@@ -429,6 +435,21 @@ classes:
       unmelt_to_slots:
         range: SlotReference
         multivalued: true
+      unit_slot:
+        range: SlotReference
+        description: Optional slot containing unit information for {variable}_{unit} naming
+      slot_name_template:
+        range: string
+        ifabsent: string({variable})
+        description: Template for generating target slot names. Supports {variable} and {unit}.
+      source_slots:
+        range: SlotReference
+        multivalued: true
+        description: For MELT, the list of wide-format slots to melt
+      id_slots:
+        range: SlotReference
+        multivalued: true
+        description: Slots that identify the entity (not pivoted)
 
   KeyVal:
     attributes:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel
 from linkml_map.datamodel.transformer_model import (
     ClassDerivation,
     CollectionType,
+    PivotDirectionType,
+    PivotOperation,
     SerializationSyntaxType,
     SlotDerivation,
 )
@@ -201,6 +203,13 @@ class ObjectTransformer(Transformer):
             logger.warning(f"Unexpected: {source_obj} for type {source_type}")
             return source_obj
         class_deriv = class_derivation or self._get_class_derivation(source_type)
+
+        # Handle class-level pivot operations (UNMELT from EAV to wide format)
+        if class_deriv.pivot_operation:
+            return self._perform_pivot_operation(
+                class_deriv.pivot_operation, source_obj, class_deriv, sv, source_type
+            )
+
         tgt_attrs = {}
         bindings = None
         # map each slot assignment in source_obj, if there is a slot_derivation
@@ -213,6 +222,11 @@ class ObjectTransformer(Transformer):
                     slot_derivation.range = "string"
             elif slot_derivation.unit_conversion:
                 v = self._perform_unit_conversion(slot_derivation, source_obj, sv, source_type)
+            elif slot_derivation.pivot_operation:
+                # MELT operation: wide format to EAV/long format
+                v = self._perform_melt(
+                    slot_derivation.pivot_operation, source_obj, slot_derivation
+                )
             elif slot_derivation.expr:
                 if bindings is None:
                     bindings = Bindings(
@@ -564,3 +578,228 @@ class ObjectTransformer(Transformer):
         if enum_deriv.mirror_source:
             return str(source_value)
         return None
+
+    def _perform_pivot_operation(
+        self,
+        pivot_op: PivotOperation,
+        source_obj: DICT_OBJ,
+        class_deriv: ClassDerivation,
+        sv: SchemaView,
+        source_type: str,
+    ) -> Union[DICT_OBJ, list[DICT_OBJ]]:
+        """
+        Perform a pivot (MELT or UNMELT) operation.
+
+        :param pivot_op: The pivot operation configuration
+        :param source_obj: The source object to transform
+        :param class_deriv: The class derivation spec
+        :param sv: Source schema view
+        :param source_type: Source type name
+        :return: Transformed object(s)
+        """
+        if pivot_op.direction == PivotDirectionType.UNMELT:
+            return self._perform_unmelt(pivot_op, source_obj, class_deriv, sv, source_type)
+        elif pivot_op.direction == PivotDirectionType.MELT:
+            return self._perform_melt(pivot_op, source_obj, class_deriv)
+        else:
+            msg = f"Unknown pivot direction: {pivot_op.direction}"
+            raise ValueError(msg)
+
+    def _perform_unmelt(
+        self,
+        pivot_op: PivotOperation,
+        source_obj: DICT_OBJ,
+        class_deriv: ClassDerivation,
+        sv: SchemaView,
+        source_type: str,
+    ) -> DICT_OBJ:
+        """
+        Transform EAV/long format to wide format.
+
+        Handles both single record and collection-based unmelt:
+        - Single record: {att: 'len', val: 1.0} -> {len: 1.0}
+        - Collection: [{att: 'h', val: 1.8}, {att: 'w', val: 75}] -> {h: 1.8, w: 75}
+
+        :param pivot_op: The pivot operation configuration
+        :param source_obj: The source object (may contain EAV records)
+        :param class_deriv: The class derivation spec
+        :param sv: Source schema view
+        :param source_type: Source type name
+        :return: Wide-format object
+        """
+        variable_slot = pivot_op.variable_slot or "variable"
+        value_slot = pivot_op.value_slot or "value"
+        unit_slot = pivot_op.unit_slot
+        template = pivot_op.slot_name_template or "{variable}"
+
+        # Check if source_obj itself is an EAV record (has variable and value slots)
+        if variable_slot in source_obj and value_slot in source_obj:
+            return self._unmelt_single_record(
+                pivot_op, source_obj, variable_slot, value_slot, unit_slot, template
+            )
+
+        # Otherwise, look for a collection of EAV records in the source
+        # Try to find a multivalued slot containing EAV records
+        for slot_name, slot_value in source_obj.items():
+            if isinstance(slot_value, list) and len(slot_value) > 0:
+                first_item = slot_value[0]
+                if isinstance(first_item, dict) and variable_slot in first_item:
+                    return self._unmelt_collection(pivot_op, slot_value)
+
+        # Fallback: treat source_obj as a single EAV record
+        return self._unmelt_single_record(
+            pivot_op, source_obj, variable_slot, value_slot, unit_slot, template
+        )
+
+    def _unmelt_single_record(
+        self,
+        pivot_op: PivotOperation,
+        record: DICT_OBJ,
+        variable_slot: str,
+        value_slot: str,
+        unit_slot: Optional[str],
+        template: str,
+    ) -> DICT_OBJ:
+        """
+        Unmelt a single EAV record into slot assignment(s).
+
+        Example:
+            Input:  {att: 'len', val: 1.0, unit: 'm'}
+            Output: {len_m: 1.0}
+        """
+        result = {}
+
+        # Copy ID slots (non-pivoted attributes)
+        if pivot_op.id_slots:
+            for id_slot in pivot_op.id_slots:
+                if id_slot in record:
+                    result[id_slot] = record[id_slot]
+
+        # Get variable and value
+        variable = record.get(variable_slot)
+        value = record.get(value_slot)
+
+        if variable is None:
+            logger.warning(f"No variable found in slot '{variable_slot}'")
+            return result
+
+        # Generate target slot name
+        if unit_slot and unit_slot in record:
+            unit = record[unit_slot]
+            target_slot_name = template.format(variable=variable, unit=unit)
+        else:
+            target_slot_name = template.format(variable=variable, unit="")
+
+        # Validate against target schema if unmelt_to_class specified
+        if pivot_op.unmelt_to_class and self.target_schemaview:
+            valid_slots = [
+                s.name for s in self.target_schemaview.class_induced_slots(pivot_op.unmelt_to_class)
+            ]
+            if pivot_op.unmelt_to_slots:
+                valid_slots = [s for s in valid_slots if s in pivot_op.unmelt_to_slots]
+
+            if target_slot_name not in valid_slots:
+                logger.warning(
+                    f"Generated slot name '{target_slot_name}' not in valid slots for "
+                    f"class '{pivot_op.unmelt_to_class}'"
+                )
+
+        result[target_slot_name] = value
+        return result
+
+    def _unmelt_collection(
+        self,
+        pivot_op: PivotOperation,
+        records: list[DICT_OBJ],
+    ) -> DICT_OBJ:
+        """
+        Unmelt a collection of EAV records into a single wide object.
+
+        Example:
+            Input:  [{att: 'height', val: 1.8}, {att: 'weight', val: 75.0}]
+            Output: {height: 1.8, weight: 75.0}
+        """
+        result = {}
+        variable_slot = pivot_op.variable_slot or "variable"
+        value_slot = pivot_op.value_slot or "value"
+        unit_slot = pivot_op.unit_slot
+        template = pivot_op.slot_name_template or "{variable}"
+
+        for record in records:
+            variable = record.get(variable_slot)
+            value = record.get(value_slot)
+
+            if variable is None:
+                continue
+
+            if unit_slot and unit_slot in record:
+                unit = record[unit_slot]
+                target_slot = template.format(variable=variable, unit=unit)
+            else:
+                target_slot = template.format(variable=variable, unit="")
+
+            if target_slot in result:
+                logger.warning(f"Duplicate variable '{variable}' in unmelt; last value wins")
+
+            result[target_slot] = value
+
+        # Copy ID slots from the first record (assuming they're the same across all)
+        if pivot_op.id_slots and records:
+            for id_slot in pivot_op.id_slots:
+                if id_slot in records[0]:
+                    result[id_slot] = records[0][id_slot]
+
+        return result
+
+    def _perform_melt(
+        self,
+        pivot_op: PivotOperation,
+        source_obj: DICT_OBJ,
+        slot_derivation: Optional[SlotDerivation] = None,
+    ) -> list[DICT_OBJ]:
+        """
+        Transform wide format to EAV/long format.
+
+        Example:
+            Input:  {height: 1.8, weight: 75.0}
+            Output: [{variable: 'height', value: 1.8}, {variable: 'weight', value: 75.0}]
+
+        :param pivot_op: The pivot operation configuration
+        :param source_obj: The source object in wide format
+        :param slot_derivation: Optional slot derivation (for context)
+        :return: List of EAV records
+        """
+        variable_slot = pivot_op.variable_slot or "variable"
+        value_slot = pivot_op.value_slot or "value"
+
+        # Determine which slots to melt
+        if pivot_op.source_slots:
+            slots_to_melt = list(pivot_op.source_slots)
+        elif pivot_op.unmelt_to_class and self.target_schemaview:
+            # Infer from target class
+            slots_to_melt = [
+                s.name for s in self.target_schemaview.class_induced_slots(pivot_op.unmelt_to_class)
+            ]
+        else:
+            # Melt all non-ID slots
+            id_slots = set(pivot_op.id_slots or [])
+            slots_to_melt = [k for k in source_obj.keys() if k not in id_slots]
+
+        results = []
+        base_record = {}
+
+        # Copy ID slots to base record
+        if pivot_op.id_slots:
+            for id_slot in pivot_op.id_slots:
+                if id_slot in source_obj:
+                    base_record[id_slot] = source_obj[id_slot]
+
+        # Create one record per melted slot
+        for slot_name in slots_to_melt:
+            if slot_name in source_obj and source_obj[slot_name] is not None:
+                record = base_record.copy()
+                record[variable_slot] = slot_name
+                record[value_slot] = source_obj[slot_name]
+                results.append(record)
+
+        return results

--- a/tests/test_transformer/test_pivot_operation.py
+++ b/tests/test_transformer/test_pivot_operation.py
@@ -1,0 +1,432 @@
+"""Test pivot (melt/unmelt) operations."""
+
+from linkml_runtime import SchemaView
+
+from linkml_map.transformer.object_transformer import ObjectTransformer
+
+# --- Minimal schemas for testing ---
+
+EAV_SOURCE_SCHEMA = """
+id: https://example.org/eav
+name: eav-source
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+classes:
+  Measurement:
+    attributes:
+      att:
+        range: string
+      val:
+        range: float
+      unit:
+        range: string
+        required: false
+
+  MeasurementContainer:
+    tree_root: true
+    attributes:
+      id:
+        range: string
+      measurements:
+        range: Measurement
+        multivalued: true
+        inlined: true
+"""
+
+WIDE_TARGET_SCHEMA = """
+id: https://example.org/wide
+name: wide-target
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+classes:
+  WideRecord:
+    tree_root: true
+    attributes:
+      id:
+        range: string
+      height:
+        range: float
+      weight:
+        range: float
+      height_m:
+        range: float
+      weight_kg:
+        range: float
+      len_m:
+        range: float
+"""
+
+WIDE_SOURCE_SCHEMA = """
+id: https://example.org/wide-source
+name: wide-source
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+classes:
+  WideRecord:
+    tree_root: true
+    attributes:
+      id:
+        range: string
+      height:
+        range: float
+      weight:
+        range: float
+      # Placeholder for MELT tests - the measurements slot is derived via pivot
+      measurements:
+        range: string
+        multivalued: true
+"""
+
+EAV_TARGET_SCHEMA = """
+id: https://example.org/eav-target
+name: eav-target
+prefixes:
+  linkml: https://w3id.org/linkml/
+
+imports:
+  - linkml:types
+
+classes:
+  MeasurementResult:
+    tree_root: true
+    attributes:
+      id:
+        range: string
+      measurements:
+        range: Measurement
+        multivalued: true
+        inlined: true
+
+  Measurement:
+    attributes:
+      variable:
+        range: string
+      value:
+        range: float
+"""
+
+
+class TestUnmeltBasic:
+    """Test UNMELT operation: EAV to wide format."""
+
+    def test_unmelt_single_record(self) -> None:
+        """Single EAV record transforms to wide format slot."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "Measurement",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {"att": "height", "val": 1.8}
+        result = obj_tr.map_object(source_obj, source_type="Measurement")
+
+        assert result == {"height": 1.8}
+
+    def test_unmelt_collection(self) -> None:
+        """Collection of EAV records transforms to single wide object."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "MeasurementContainer",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {
+            "id": "container1",
+            "measurements": [
+                {"att": "height", "val": 1.8},
+                {"att": "weight", "val": 75.0},
+            ],
+        }
+        result = obj_tr.map_object(source_obj, source_type="MeasurementContainer")
+
+        assert result == {"height": 1.8, "weight": 75.0}
+
+
+class TestUnmeltWithUnit:
+    """Test UNMELT with unit-aware slot naming."""
+
+    def test_unmelt_with_unit_template(self) -> None:
+        """EAV with unit transforms to slot name with unit suffix."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "Measurement",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                        "unit_slot": "unit",
+                        "slot_name_template": "{variable}_{unit}",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {"att": "len", "val": 1.0, "unit": "m"}
+        result = obj_tr.map_object(source_obj, source_type="Measurement")
+
+        assert result == {"len_m": 1.0}
+
+    def test_unmelt_collection_with_units(self) -> None:
+        """Collection of EAV records with units transforms correctly."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "MeasurementContainer",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                        "unit_slot": "unit",
+                        "slot_name_template": "{variable}_{unit}",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {
+            "measurements": [
+                {"att": "height", "val": 1.8, "unit": "m"},
+                {"att": "weight", "val": 75.0, "unit": "kg"},
+            ],
+        }
+        result = obj_tr.map_object(source_obj, source_type="MeasurementContainer")
+
+        assert result == {"height_m": 1.8, "weight_kg": 75.0}
+
+
+class TestMeltBasic:
+    """Test MELT operation: wide to EAV format."""
+
+    def test_melt_basic(self) -> None:
+        """Wide format transforms to EAV records."""
+        source_sv = SchemaView(WIDE_SOURCE_SCHEMA)
+        target_sv = SchemaView(EAV_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "MeasurementResult": {
+                    "populated_from": "WideRecord",
+                    "slot_derivations": {
+                        "id": {"populated_from": "id"},
+                        "measurements": {
+                            "pivot_operation": {
+                                "direction": "MELT",
+                                "variable_slot": "variable",
+                                "value_slot": "value",
+                                "source_slots": ["height", "weight"],
+                                "id_slots": ["id"],
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {"id": "p1", "height": 1.8, "weight": 75.0}
+        result = obj_tr.map_object(source_obj, source_type="WideRecord")
+
+        assert result["id"] == "p1"
+        assert len(result["measurements"]) == 2
+
+        # Sort by variable name for consistent comparison
+        measurements = sorted(result["measurements"], key=lambda x: x["variable"])
+        # id_slots includes 'id', so each record has it
+        assert measurements[0] == {"id": "p1", "variable": "height", "value": 1.8}
+        assert measurements[1] == {"id": "p1", "variable": "weight", "value": 75.0}
+
+    def test_melt_with_id_slots(self) -> None:
+        """MELT operation preserves id_slots in each record."""
+        source_sv = SchemaView(WIDE_SOURCE_SCHEMA)
+        target_sv = SchemaView(EAV_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "MeasurementResult": {
+                    "populated_from": "WideRecord",
+                    "slot_derivations": {
+                        "measurements": {
+                            "pivot_operation": {
+                                "direction": "MELT",
+                                "variable_slot": "variable",
+                                "value_slot": "value",
+                                "source_slots": ["height", "weight"],
+                                "id_slots": ["id"],
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        source_obj = {"id": "p1", "height": 1.8, "weight": 75.0}
+        result = obj_tr.map_object(source_obj, source_type="WideRecord")
+
+        # Each melted record should have the id
+        for measurement in result["measurements"]:
+            assert measurement.get("id") == "p1"
+
+
+class TestEdgeCases:
+    """Test edge cases for pivot operations."""
+
+    def test_unmelt_missing_value(self) -> None:
+        """UNMELT handles missing value gracefully."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "Measurement",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        # Missing value slot
+        source_obj = {"att": "height"}
+        result = obj_tr.map_object(source_obj, source_type="Measurement")
+
+        assert result == {"height": None}
+
+    def test_unmelt_missing_variable(self) -> None:
+        """UNMELT handles missing variable gracefully."""
+        source_sv = SchemaView(EAV_SOURCE_SCHEMA)
+        target_sv = SchemaView(WIDE_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "WideRecord": {
+                    "populated_from": "Measurement",
+                    "pivot_operation": {
+                        "direction": "UNMELT",
+                        "variable_slot": "att",
+                        "value_slot": "val",
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        # Missing variable slot - should return empty dict
+        source_obj = {"val": 1.8}
+        result = obj_tr.map_object(source_obj, source_type="Measurement")
+
+        assert result == {}
+
+    def test_melt_null_values_skipped(self) -> None:
+        """MELT skips slots with null values."""
+        source_sv = SchemaView(WIDE_SOURCE_SCHEMA)
+        target_sv = SchemaView(EAV_TARGET_SCHEMA)
+
+        transform_spec = {
+            "class_derivations": {
+                "MeasurementResult": {
+                    "populated_from": "WideRecord",
+                    "slot_derivations": {
+                        "measurements": {
+                            "pivot_operation": {
+                                "direction": "MELT",
+                                "variable_slot": "variable",
+                                "value_slot": "value",
+                                "source_slots": ["height", "weight"],
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        obj_tr = ObjectTransformer()
+        obj_tr.source_schemaview = source_sv
+        obj_tr.target_schemaview = target_sv
+        obj_tr.create_transformer_specification(transform_spec)
+
+        # weight is None, should be skipped
+        source_obj = {"height": 1.8, "weight": None}
+        result = obj_tr.map_object(source_obj, source_type="WideRecord")
+
+        assert len(result["measurements"]) == 1
+        assert result["measurements"][0] == {"variable": "height", "value": 1.8}


### PR DESCRIPTION
## Summary

- Implements the `PivotOperation` feature for transforming between EAV/long format and wide format data structures (Issue #103)
- Applies incremental refactoring pattern from Issue #104 by extracting pivot logic into separate methods

## Changes

**Schema** (`transformer_model.yaml`):
- Added `pivot_operation` field to `ClassDerivation` (for class-level UNMELT)
- Added `pivot_operation` field to `SlotDerivation` (for slot-level MELT)
- Extended `PivotOperation` with:
  - `unit_slot` - for unit-aware slot naming
  - `slot_name_template` - template like `{variable}_{unit}`
  - `source_slots` - list of slots to melt
  - `id_slots` - slots preserved during pivot

**Implementation** (`object_transformer.py`):
- `_perform_pivot_operation()` - dispatcher for MELT/UNMELT
- `_perform_unmelt()` - EAV to wide format
- `_unmelt_single_record()` - single record UNMELT
- `_unmelt_collection()` - collection UNMELT
- `_perform_melt()` - wide to EAV format

## Example Usage

**UNMELT** (EAV to wide):
```yaml
class_derivations:
  WideRecord:
    pivot_operation:
      direction: UNMELT
      variable_slot: att
      value_slot: val
      unit_slot: unit
      slot_name_template: "{variable}_{unit}"
```
Input: `{att: 'len', val: 1.0, unit: 'm'}` → Output: `{len_m: 1.0}`

**MELT** (wide to EAV):
```yaml
class_derivations:
  EAVRecord:
    slot_derivations:
      measurements:
        pivot_operation:
          direction: MELT
          source_slots: [height, weight]
          id_slots: [id]
```
Input: `{id: 'p1', height: 1.8}` → Output: `{measurements: [{id: 'p1', variable: 'height', value: 1.8}]}`

## Test plan

- [x] Test single record UNMELT
- [x] Test collection UNMELT
- [x] Test UNMELT with unit-aware naming (`len_m` from `len` + `m`)
- [x] Test basic MELT
- [x] Test MELT with id_slots preservation
- [x] Test edge cases (missing values, null handling)
- [x] Run full test suite (245 passed)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)