### PR TITLE
NMDC: Document inlined-object flattening to lakehouse-style columns (tests only)

### DIFF
--- a/tests/test_transformer/test_flatten_inlined.py
+++ b/tests/test_transformer/test_flatten_inlined.py
@@ -8,6 +8,8 @@ QuantityValue composites into simple value+unit columns.
 See: https://github.com/linkml/linkml-map/issues/128
 """
 
+import copy
+
 import pytest
 from linkml_runtime import SchemaView
 
@@ -90,7 +92,7 @@ def _make_transformer() -> ObjectTransformer:
     obj_tr = ObjectTransformer()
     obj_tr.source_schemaview = SchemaView(SOURCE_SCHEMA)
     obj_tr.target_schemaview = SchemaView(TARGET_SCHEMA)
-    obj_tr.create_transformer_specification(TRANSFORM_SPEC)
+    obj_tr.create_transformer_specification(copy.deepcopy(TRANSFORM_SPEC))
     return obj_tr
 
 


### PR DESCRIPTION
Closes #128

## NMDC Relevance
This test documents a core NMDC flattening pattern: mapping structured inlined measurement objects (for example `QuantityValue`) into flat scalar columns needed for lakehouse-style tables.

## What This PR Adds
- Test-only coverage for dot-notation `expr` flattening on inlined objects.
- No code changes; validates existing behavior on current `main`.

## Coverage
- Complete inlined object flattening
- Null inlined object handling
- Partial object handling
- Scalar slot propagation regardless of nested-object state

## Why It Matters
For NMDC pipelines, this confirms linkml-map already supports a common transform shape used when moving from nested biosample-style records to flat tabular outputs.