### PR TITLE
Coerce numeric strings in comparison operators

### DIFF
--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -128,15 +128,17 @@ def _maybe_coerce_numeric(left: Any, right: Any) -> tuple[Any, Any]:  # noqa: AN
     (1, 'abc')
     >>> _maybe_coerce_numeric('a', 'b')
     ('a', 'b')
+    >>> _maybe_coerce_numeric(True, '0')
+    (True, '0')
     """
     if type(left) is type(right):
         return left, right
-    if isinstance(left, (int, float)) and isinstance(right, str):
+    if isinstance(left, (int, float)) and not isinstance(left, bool) and isinstance(right, str):
         try:
             return left, type(left)(right)
         except (ValueError, TypeError):
             return left, right
-    if isinstance(right, (int, float)) and isinstance(left, str):
+    if isinstance(right, (int, float)) and not isinstance(right, bool) and isinstance(left, str):
         try:
             return type(right)(left), right
         except (ValueError, TypeError):

--- a/tests/test_utils/test_eval_utils.py
+++ b/tests/test_utils/test_eval_utils.py
@@ -587,3 +587,9 @@ def test_case_with_numeric_string_coercion() -> None:
 def test_ordering_comparison_with_numeric_string_coercion() -> None:
     """Ordering comparisons coerce numeric strings (#133)."""
     assert eval_expr("{x} < '2'", x=1) is True
+
+
+def test_bool_not_coerced_as_numeric() -> None:
+    """Booleans should not be coerced via numeric-string path (#135)."""
+    assert eval_expr("{flag} == '0'", flag=True) is False
+    assert eval_expr("{flag} == '1'", flag=False) is False


### PR DESCRIPTION
## Summary

- When TSV/CSV data is loaded via linkml loaders, numeric fields become `int`/`float`, but spec authors naturally write comparisons against string literals like `case(({status} == '1', 'active'), ...)`. This caused `1 == '1'` to silently return `False` and `1 < '2'` to raise `TypeError`.
- Wraps the six comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) in `LinkMLEvaluator` so that `int`/`float` vs `str` operands are coerced before comparison. Non-numeric strings are left unchanged.
- Fixes #133

## Test plan

- [x] Doctests on `_maybe_coerce_numeric` cover coercion logic
- [x] Integration test: `case()` with `{status} == '1'` and `status=1`
- [x] Integration test: ordering comparison `{x} < '2'` with `x=1`
- [ ] `uv run pytest tests/test_utils/test_eval_utils.py -v`
- [ ] `uv run pytest --doctest-modules src/linkml_map/utils/eval_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)