### PR TITLE
Support enum mapping for slots with multiple enum ranges (any_of)

### DIFF
--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -488,7 +488,7 @@ class ObjectTransformer(Transformer):
         source_class_slot_range = source_class_slot.range
         sv = self.source_schemaview
 
-        # Check for enum ranges (direct or via any_of)
+        # Check for enums defined via any_of when the range is None or "Any"
         if source_class_slot_range is None or source_class_slot_range == "Any":
             any_of_enums = self._get_any_of_enum_names(source_class_slot, sv)
             if any_of_enums:

--- a/tests/test_transformer/test_multi_enum.py
+++ b/tests/test_transformer/test_multi_enum.py
@@ -289,3 +289,19 @@ def test_null_color_stays_none():
     source = {"id": "light1", "color": None}
     result = tr.map_object(source, source_type="Light")
     assert result["color"] is None
+
+
+def test_explicit_range_any_with_any_of():
+    """Slots with explicit range: Any plus any_of enum ranges are mapped correctly."""
+    schema = SOURCE_SCHEMA.replace(
+        "      color:\n        any_of:",
+        "      color:\n        range: Any\n        any_of:",
+    )
+    tr = ObjectTransformer()
+    tr.source_schemaview = SchemaView(schema)
+    tr.target_schemaview = SchemaView(TARGET_SCHEMA)
+    tr.create_transformer_specification(copy.deepcopy(TRANSFORM_SPEC))
+
+    source = {"id": "light1", "color": "light_red"}
+    result = tr.map_object(source, source_type="Light")
+    assert result["color"] == "red"


### PR DESCRIPTION
## Summary

- Slots using `any_of` to specify multiple enum ranges are now correctly transformed
- `transform_enum` accepts a list of enum names and iterates in order until a match is found
- Enum handling integrated into `_map_value_by_range` — values flow through the normal coercion/reshaping pipeline (no `continue` hack)
- Handles both `range: None` and `range: Any` with `any_of` enum ranges
- Add `_get_any_of_enum_names` static method to extract enum names from any_of constraints
- Clean up stale EXTRACT markers and step comments from prior refactor

Closes #146

## Test plan

- [x] 13 new enum-specific tests (single-valued, multivalued, container, mirror_source, no match, null)
- [x] All 124 transformer tests pass
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)