### PR TITLE
Add NMDC Biosample-Study cross-table join tests (#136)

### DIFF
--- a/tests/test_transformer/test_nmdc_biosample_study_join.py
+++ b/tests/test_transformer/test_nmdc_biosample_study_join.py
@@ -5,7 +5,7 @@ enriched with Study metadata (PI name, ecosystem, study name) by joining
 on ``associated_studies``. This is the pattern needed for NMDC lakehouse
 tables where biosample rows carry denormalized study context.
 
-This test requires the ``cross-table-lookup`` branch (PR #136).
+This test requires the cross-table join feature introduced in PR #136.
 
 See also:
 - PR #136 (cross-table lookup support)


### PR DESCRIPTION
## Summary
- Adds 2 integration tests for the `joins:` feature landed in PR #136
- Tests Biosample-Study denormalization: enriching biosample rows with Study metadata (PI name, ecosystem, study name) by joining on `associated_studies`
- Covers matched joins (2 biosamples with corresponding studies), orphan handling (null propagation when study doesn't exist), and field preservation with active joins

## Test plan
- [x] Both tests pass locally on `main` (post-#136 merge)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)