### PR TITLE
Use transform_spec engine for CLI map-data, add --target-schema

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import sys
-from collections.abc import Iterator
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -19,6 +18,7 @@ from linkml_map.compiler.python_compiler import PythonCompiler
 from linkml_map.inference.inverter import TransformationSpecificationInverter
 from linkml_map.inference.schema_mapper import SchemaMapper
 from linkml_map.loaders import DataLoader
+from linkml_map.transformer.engine import transform_spec
 from linkml_map.transformer.object_transformer import ObjectTransformer
 from linkml_map.writers import (
     EXTENSION_FORMAT_MAP,
@@ -39,6 +39,9 @@ output_option = click.option("-o", "--output", help="Output file.")
 schema_option = click.option("-s", "--schema", help="Path to source schema.")
 transformer_specification_option = click.option(
     "-T", "--transformer-specification", help="Path to transformer specification."
+)
+target_schema_option = click.option(
+    "--target-schema", help="Path to target schema (required for nested object_derivations)."
 )
 
 logger = logging.getLogger(__name__)
@@ -66,6 +69,7 @@ def main(verbose: int, quiet: bool) -> None:
 @output_option
 @transformer_specification_option
 @schema_option
+@target_schema_option
 @click.option("--source-type", help="Source type/class name for the input data.")
 @click.option(
     "--unrestricted-eval/--no-unrestricted-eval",
@@ -103,6 +107,7 @@ def map_data(
     output_format: Optional[str],
     chunk_size: int,
     additional_output: tuple,
+    target_schema: Optional[str] = None,
     **kwargs: dict[str, Any],
 ) -> None:
     """
@@ -160,6 +165,7 @@ def map_data(
             output_format=output_format,
             chunk_size=chunk_size,
             additional_output=additional_output,
+            target_schema=target_schema,
             **kwargs,
         )
     else:
@@ -171,6 +177,7 @@ def map_data(
             transformer_specification=transformer_specification,
             output=output,
             output_format=output_format,
+            target_schema=target_schema,
             **kwargs,
         )
 
@@ -182,12 +189,15 @@ def _map_data_single(
     transformer_specification: str,
     output: Optional[str],
     output_format: str,
+    target_schema: Optional[str] = None,
     **kwargs: dict[str, Any],
 ) -> None:
     """Original single-object transformation logic."""
     tr = ObjectTransformer(**kwargs)
     tr.source_schemaview = SchemaView(schema)
     tr.load_transformer_specification(transformer_specification)
+    if target_schema:
+        tr.target_schemaview = SchemaView(target_schema)
 
     # Load input data (YAML or JSON)
     with open(input_data) as file:
@@ -203,24 +213,6 @@ def _map_data_single(
     tr_obj = tr.map_object(input_obj, source_type)
     dump_output(tr_obj, output_format, output)
 
-
-def _transform_iterator(
-    data_loader: DataLoader,
-    transformer: ObjectTransformer,
-    source_type: Optional[str],
-) -> Iterator[dict[str, Any]]:
-    """Iterate over data and yield transformed objects."""
-    for identifier, rows in data_loader.iter_sources():
-        # Use explicit source_type if provided, otherwise use identifier from filename
-        effective_type = source_type if source_type else identifier
-        logger.info(f"Processing {identifier} as {effective_type}")
-        for row in rows:
-            try:
-                mapped = transformer.map_object(row, source_type=effective_type)
-                yield mapped
-            except Exception as e:
-                logger.warning(f"Error transforming row from {identifier}: {e}")
-                raise
 
 
 def _build_additional_outputs(
@@ -253,6 +245,7 @@ def _map_data_streaming(
     output_format: str,
     chunk_size: int,
     additional_output: tuple = (),
+    target_schema: Optional[str] = None,
     **kwargs: dict[str, Any],
 ) -> None:
     """Streaming transformation for tabular/directory input."""
@@ -260,12 +253,14 @@ def _map_data_streaming(
     tr = ObjectTransformer(**kwargs)
     tr.source_schemaview = SchemaView(schema)
     tr.load_transformer_specification(transformer_specification)
+    if target_schema:
+        tr.target_schemaview = SchemaView(target_schema)
 
     # Initialize data loader
     data_loader = DataLoader(input_path)
 
     # Create transform iterator and chunk it
-    transform_iter = _transform_iterator(data_loader, tr, source_type)
+    transform_iter = transform_spec(tr, data_loader, source_type)
     chunks = chunked(transform_iter, chunk_size)
 
     # Resolve output format

--- a/src/linkml_map/loaders/data_loaders.py
+++ b/src/linkml_map/loaders/data_loaders.py
@@ -253,20 +253,24 @@ class DataLoader:
     def __contains__(self, identifier: str) -> bool:
         """Check if a data file exists for the given identifier."""
         if self.is_single_file:
-            return False
+            return identifier == self.base_path.stem
         return self._find_file(identifier) is not None
 
     def __getitem__(self, identifier: str) -> Iterator[dict[str, Any]]:
         """
         Load instances from the data file corresponding to the identifier.
 
+        For single-file mode, the identifier must match the file stem.
+
         :param identifier: The populated_from identifier to load
         :return: Iterator over data instances
         :raises FileNotFoundError: If no matching file is found
         """
         if self.is_single_file:
-            msg = "Cannot use identifier-based access on single-file loader"
-            raise ValueError(msg)
+            if identifier == self.base_path.stem:
+                return iter(self)
+            msg = f"Single-file loader has no data for identifier '{identifier}' (file stem is '{self.base_path.stem}')"
+            raise FileNotFoundError(msg)
 
         file_path = self._find_file(identifier)
         if file_path is None:

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -509,3 +509,111 @@ class TestMapDataWithExistingTestData:
         first = json.loads(lines[0])
         assert "id" in first
         assert "label" in first
+
+
+class TestTransformSpecEngine:
+    """Tests verifying the CLI uses transform_spec engine correctly.
+
+    These cover the bugs from issue #155: multiple derivations sharing
+    the same populated_from, and extra data files with no derivation.
+    """
+
+    def test_multiple_derivations_same_populated_from(
+        self,
+        runner: CliRunner,
+        sample_schema: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Two class_derivations with the same populated_from should both produce output."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "Person.tsv").write_text(
+            "id\tname\tprimary_email\tage_in_years\tgender\n"
+            "P:001\tAlice\talice@example.com\t30\tcisgender woman\n"
+        )
+
+        transform_path = tmp_path / "transform.yaml"
+        transform = {
+            "id": "multi-deriv",
+            "class_derivations": {
+                "NameRecord": {
+                    "populated_from": "Person",
+                    "slot_derivations": {
+                        "id": {},
+                        "label": {"populated_from": "name"},
+                    },
+                },
+                "EmailRecord": {
+                    "populated_from": "Person",
+                    "slot_derivations": {
+                        "id": {},
+                        "email": {"populated_from": "primary_email"},
+                    },
+                },
+            },
+        }
+        transform_path.write_text(yaml.dump(transform))
+
+        result = runner.invoke(
+            main,
+            [
+                "map-data",
+                "-T",
+                str(transform_path),
+                "-s",
+                str(sample_schema),
+                "-f",
+                "jsonl",
+                str(data_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        # One row from each derivation = 2 output lines
+        assert len(lines) == 2
+        objs = [json.loads(line) for line in lines]
+        # Both derivations should produce output (order depends on YAML dict ordering)
+        labels = [o.get("label") for o in objs]
+        emails = [o.get("email") for o in objs]
+        assert "Alice" in labels
+        assert "alice@example.com" in emails
+
+    def test_extra_data_files_skipped(
+        self,
+        runner: CliRunner,
+        sample_schema: Path,
+        sample_transform: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Data files with no matching derivation should be silently skipped."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "Person.tsv").write_text(
+            "id\tname\tprimary_email\tage_in_years\tgender\n"
+            "P:001\tAlice\talice@example.com\t30\tcisgender woman\n"
+        )
+        # Extra file with no matching class_derivation
+        (data_dir / "Organization.tsv").write_text(
+            "id\tname\n"
+            "O:001\tAcme Corp\n"
+        )
+
+        result = runner.invoke(
+            main,
+            [
+                "map-data",
+                "-T",
+                str(sample_transform),
+                "-s",
+                str(sample_schema),
+                "-f",
+                "jsonl",
+                str(data_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        # Only Person rows should appear (Organization is ignored)
+        assert len(lines) == 1
+        obj = json.loads(lines[0])
+        assert obj["label"] == "Alice"

--- a/tests/test_loaders/test_data_loader.py
+++ b/tests/test_loaders/test_data_loader.py
@@ -114,10 +114,18 @@ class TestDataLoaderSingleFile:
         assert rows[0]["id"] == "P:006"
         assert rows[0]["name"] == "Frank"
 
-    def test_single_file_cannot_use_identifier(self, sample_tsv_file: Path) -> None:
+    def test_single_file_identifier_matching_stem(self, sample_tsv_file: Path) -> None:
+        """Single-file loader supports identifier access when it matches the file stem."""
         loader = DataLoader(sample_tsv_file)
-        with pytest.raises(ValueError, match="Cannot use identifier-based access"):
-            _ = loader["Person"]
+        rows = list(loader["Person"])
+        assert len(rows) == 2
+        assert rows[0]["name"] == "Alice"
+
+    def test_single_file_identifier_not_matching_stem(self, sample_tsv_file: Path) -> None:
+        """Single-file loader raises FileNotFoundError for non-matching identifiers."""
+        loader = DataLoader(sample_tsv_file)
+        with pytest.raises(FileNotFoundError, match="Single-file loader has no data"):
+            _ = list(loader["Organization"])
 
     def test_is_single_file_property(self, sample_tsv_file: Path) -> None:
         loader = DataLoader(sample_tsv_file)


### PR DESCRIPTION
## Summary

- Replace `_transform_iterator` with `transform_spec()` from `engine.py` in the CLI's streaming path, fixing two bugs:
  - Multiple `class_derivations` sharing the same `populated_from` now work correctly (engine iterates over derivations, not files)
  - Extra data files with no matching derivation are silently skipped instead of raising errors
- Add `--target-schema` CLI option for specs that use `object_derivations` referencing the target schema
- Extend `DataLoader` to support identifier-based access in single-file mode (matching against file stem)

## Test plan

- [x] Existing 12 CLI tabular tests pass
- [x] New test: two derivations with same `populated_from` both produce output
- [x] New test: extra data files with no matching derivation are skipped
- [x] Updated DataLoader tests for new single-file identifier behavior
- [x] Full test suite (462 tests) passes

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)