### PR TITLE
Replace live biolink fetch in tests with local fixture

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,9 +36,7 @@ FLATTENING_DATA = FLATTENING_BASIC_EXAMPLE_DIR / DATA / "MappingSet-001.yaml"
 
 BIOLINK_BASIC_EXAMPLE_DIR = Path(EXAMPLE_DIR) / "biolink"
 BIOLINK_SRC_SCHEMA = BIOLINK_BASIC_EXAMPLE_DIR / SRC / "biolink-model.yaml"
-BIOLINK_TGT_SCHEMA = BIOLINK_BASIC_EXAMPLE_DIR / TGT / "monarch.yaml"
 BIOLINK_TR = BIOLINK_BASIC_EXAMPLE_DIR / TR / "biolink-example-profile.transform.yaml"
-BIOLINK_DATA = BIOLINK_BASIC_EXAMPLE_DIR / DATA / "Association-001.yaml"
 
 
 # TODO: migrate these to example dir

--- a/tests/test_transformer/test_biolink_subsetting.py
+++ b/tests/test_transformer/test_biolink_subsetting.py
@@ -84,11 +84,23 @@ def test_biolink_subsetting_manual(
 
     transformed_sv = SchemaView(dump_output)
 
-    for class_name in transformed_sv.all_classes():
-        print(class_name)
-    print()
-    for slot_name in transformed_sv.all_slots():
-        print(slot_name)
+    derived_classes = set(transformed_sv.all_classes())
+    expected_classes = {
+        "NamedThing",
+        "Gene",
+        "Disease",
+        "PhenotypicFeature",
+        "Association",
+        "GeneToPhenotypicFeatureAssociation",
+    }
+    assert expected_classes <= derived_classes, f"Missing classes: {expected_classes - derived_classes}"
+
+    derived_slots = set(transformed_sv.all_slots())
+    assert "id" in derived_slots
+    assert "symbol" in derived_slots
+    assert "subject" in derived_slots
+    assert "predicate" in derived_slots
+    assert "object" in derived_slots
 
 
 def test_biolink_subset_auto(biolink_schema: SchemaView, tmp_path: Path) -> None:
@@ -141,12 +153,20 @@ def test_biolink_subset_auto(biolink_schema: SchemaView, tmp_path: Path) -> None
 
     transformed_sv = SchemaView(dump_output)
 
-    for class_name in transformed_sv.all_classes():
-        print(class_name)
-    for slot_name in transformed_sv.all_slots():
-        print(slot_name)
-    for type_name in transformed_sv.all_types():
-        print(type_name)
+    derived_classes = set(transformed_sv.all_classes())
+    expected_classes = {
+        "Gene",
+        "Disease",
+        "CaseToPhenotypicFeatureAssociation",
+        "GeneToDiseaseAssociation",
+        "GeneToPhenotypicFeatureAssociation",
+        "Case",
+        "PhenotypicFeature",
+    }
+    assert expected_classes <= derived_classes, f"Missing classes: {expected_classes - derived_classes}"
 
-    for slot in transformed_sv.get_class("Gene").slots:
-        print(slot)
+    assert len(transformed_sv.all_slots()) > 0, "Derived schema should have slots"
+    assert len(transformed_sv.all_types()) > 0, "Derived schema should have types"
+
+    gene_slots = transformed_sv.class_induced_slots("Gene")
+    assert len(list(gene_slots)) > 0, "Gene class should have induced slots"


### PR DESCRIPTION
## Summary
- Replaced live GitHub fetch of `biolink-model.yaml` with the vendored local copy already in `tests/input/examples/biolink/source/`, eliminating HTTP 429 flaky CI failures
- Fixed `BIOLINK_SRC_SCHEMA` constant (pointed to non-existent `biolink.yaml`, now correctly points to `biolink-model.yaml`)
- Fixed `src.linkml_map.utils.loaders` import → `linkml_map.utils.loaders`; removed unused `Generator` import and incorrect type annotation

Closes #167

## Test plan
- [x] Both `test_biolink_subsetting_manual` and `test_biolink_subset_auto` pass (~1s, no network calls)
- [x] Ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)