### PR TITLE
Include populated_from in TransformationError messages

### DIFF
--- a/src/linkml_map/transformer/errors.py
+++ b/src/linkml_map/transformer/errors.py
@@ -21,7 +21,9 @@ class TransformationError(Exception):
 
     message: str
     class_derivation_name: str | None = None
+    class_populated_from: str | None = None
     slot_derivation_name: str | None = None
+    slot_populated_from: str | None = None
     source_row: dict[str, Any] | None = field(default=None, repr=False)
     row_index: int | None = None
     cause: Exception | None = field(default=None, repr=False)
@@ -29,12 +31,22 @@ class TransformationError(Exception):
     def __post_init__(self) -> None:
         super().__init__(self.message)
 
+    def _format_derivation(self, label: str, name: str | None, populated_from: str | None) -> str:
+        """Format a derivation field with optional source context."""
+        if not name:
+            return ""
+        if populated_from:
+            return f"{label}={name} (from {populated_from})"
+        return f"{label}={name}"
+
     def __str__(self) -> str:
         parts = [self.message]
-        if self.class_derivation_name:
-            parts.append(f"class_derivation={self.class_derivation_name}")
-        if self.slot_derivation_name:
-            parts.append(f"slot_derivation={self.slot_derivation_name}")
+        class_part = self._format_derivation("class_derivation", self.class_derivation_name, self.class_populated_from)
+        if class_part:
+            parts.append(class_part)
+        slot_part = self._format_derivation("slot_derivation", self.slot_derivation_name, self.slot_populated_from)
+        if slot_part:
+            parts.append(slot_part)
         if self.row_index is not None:
             parts.append(f"row={self.row_index}")
         return "; ".join(parts)

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -350,7 +350,9 @@ class ObjectTransformer(Transformer):
                 raise TransformationError(
                     message=str(exc),
                     class_derivation_name=class_deriv.name,
+                    class_populated_from=class_deriv.populated_from,
                     slot_derivation_name=slot_derivation.name,
+                    slot_populated_from=slot_derivation.populated_from,
                     source_row=source_obj,
                     cause=exc,
                 ) from exc

--- a/tests/test_transformer/test_continue_on_error.py
+++ b/tests/test_transformer/test_continue_on_error.py
@@ -71,6 +71,36 @@ def test_transformation_error_str_minimal():
     assert str(err) == "oops"
 
 
+def test_transformation_error_str_with_populated_from():
+    """Source context (populated_from) appears in string representation."""
+    err = TransformationError(
+        message="bad value",
+        class_derivation_name="Quantity",
+        class_populated_from="pht004041",
+        slot_derivation_name="value_decimal",
+        slot_populated_from="phv00191041",
+        row_index=5,
+    )
+    s = str(err)
+    assert "class_derivation=Quantity (from pht004041)" in s
+    assert "slot_derivation=value_decimal (from phv00191041)" in s
+    assert "row=5" in s
+
+
+def test_transformation_error_str_partial_populated_from():
+    """populated_from only shown when present."""
+    err = TransformationError(
+        message="bad value",
+        class_derivation_name="Quantity",
+        slot_derivation_name="value_decimal",
+        slot_populated_from="phv00191041",
+    )
+    s = str(err)
+    assert "class_derivation=Quantity;" in s or "class_derivation=Quantity" in s
+    assert "(from" not in s.split("class_derivation=Quantity")[1].split(";")[0]
+    assert "slot_derivation=value_decimal (from phv00191041)" in s
+
+
 def test_transformation_error_is_exception():
     """TransformationError can be raised and caught as Exception."""
     with pytest.raises(TransformationError, match="test"):


### PR DESCRIPTION
## Summary

Closes #183

Adds source context to `TransformationError` so curators can identify which source table/column caused the error without opening the YAML spec.

### Before
```
could not convert string to float: 'A'; class_derivation=Quantity; slot_derivation=value_decimal
```

### After
```
could not convert string to float: 'A'; class_derivation=Quantity (from pht004041); slot_derivation=value_decimal (from phv00191041)
```

## Changes

- Added `class_populated_from` and `slot_populated_from` fields to `TransformationError`
- Updated `__str__` to append `(from ...)` when populated_from is present
- Pass both fields when constructing the error in `map_object`

## Test plan

- [x] New test: all fields including populated_from in string output
- [x] New test: partial populated_from (only slot, not class)
- [x] Existing tests still pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)