### PR TITLE
Fix requires-python upper bound: <=3.13 → <3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = [
     {name = "cmungall", email = "cjm@berkeleybop.org"},
 ]
-requires-python = "<=3.13,>=3.10"
+requires-python = ">=3.10,<3.14"
 dynamic = [ "version" ]
 
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <=3.13"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",


### PR DESCRIPTION
## Summary
- Fix `requires-python` from `<=3.13` to `<3.14`
- `<=3.13` is interpreted as `<=3.13.0` by uv, excluding 3.13.1+ patch versions and breaking downstream resolution

## Test plan
- [x] 553 tests pass
- [ ] CI passes
- Verified downstream: pinning `linkml-map>=0.5.0` with `<3.14` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)