### PR TITLE
Deprecate object_derivations in favor of slot-level class_derivations

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -41,9 +41,7 @@ schema_option = click.option("-s", "--schema", help="Path to source schema.")
 transformer_specification_option = click.option(
     "-T", "--transformer-specification", help="Path to transformer specification."
 )
-target_schema_option = click.option(
-    "--target-schema", help="Path to target schema (required for nested object_derivations)."
-)
+target_schema_option = click.option("--target-schema", help="Path to target schema.")
 
 logger = logging.getLogger(__name__)
 

--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -189,7 +189,9 @@ class TransformationSpecification(SpecificationComponent):
     mapping_method: Optional[str] = Field(default=None, description="""The method used to create this mapping, e.g. manual curation, automated mapping, etc.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     documentation: Optional[str] = Field(default=None, description="""URL or reference to documentation for the mapping specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     content_url: Optional[str] = Field(default=None, description="""Reference to the actual content of the mapping specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
-    class_derivations: Optional[list[ClassDerivation]] = Field(default_factory=list, description="""Instructions on how to derive a set of classes in the target schema from classes in the source schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ObjectDerivation']} })
+    class_derivations: Optional[list[ClassDerivation]] = Field(default_factory=list, description="""Instructions on how to derive a set of classes in the target schema from classes in the source schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification',
+                       'ObjectDerivation',
+                       'SlotDerivation']} })
     enum_derivations: Optional[dict[str, EnumDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of enums in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     slot_derivations: Optional[dict[str, SlotDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of top level slots in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ClassDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
@@ -296,7 +298,9 @@ class ObjectDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    class_derivations: Optional[dict[str, ClassDerivation]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ObjectDerivation']} })
+    class_derivations: Optional[dict[str, ClassDerivation]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification',
+                       'ObjectDerivation',
+                       'SlotDerivation']} })
     copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
@@ -347,6 +351,9 @@ class SlotDerivation(ElementDerivation):
                        'SlotDerivation',
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
+    class_derivations: Optional[list[ClassDerivation]] = Field(default_factory=list, description="""Instructions on how to derive nested class instances for this slot. Each entry specifies how to construct an instance of a target class from source data. For multivalued slots, each entry produces one object in the resulting list.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification',
+                       'ObjectDerivation',
+                       'SlotDerivation']} })
     object_derivations: Optional[list[ObjectDerivation]] = Field(default_factory=list, description="""Deprecated. Use list-based class_derivations instead. One or more object derivations used to construct the slot value(s), which must be instances of a class.""", json_schema_extra = { "linkml_meta": {'deprecated': 'Use list-based class_derivations instead of nesting via '
                        'object_derivations. See '
                        'https://github.com/linkml/linkml-map/issues/112',

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -304,6 +304,16 @@ classes:
           list support in populated_from. Will be removed in a future version.
         description: >-
           Deprecated. Use populated_from instead.
+      class_derivations:
+        description: >-
+          Instructions on how to derive nested class instances for this slot.
+          Each entry specifies how to construct an instance of a target class
+          from source data. For multivalued slots, each entry produces one
+          object in the resulting list.
+        range: ClassDerivation
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
       object_derivations:
         deprecated: >-
           Use list-based class_derivations instead of nesting via object_derivations.

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -11,9 +11,10 @@ from linkml_map.utils.fk_utils import resolve_fk_path
 def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
     """Emit deprecation warnings for use of deprecated fields.
 
-    Checks for ``sources`` (deprecated in favor of ``populated_from``),
-    ``object_derivations`` (deprecated in favor of ``class_derivations``),
+    Checks for ``sources`` (deprecated in favor of ``populated_from``)
     and ``derived_from`` (deprecated, unused by runtime).
+    ``object_derivations`` warnings are emitted during normalization
+    (see ``Transformer._normalize_slot_class_derivations``).
     Warnings are collapsed to one per field per derivation type to avoid noise.
     """
     sources_counts: dict[str, list[str]] = {
@@ -22,7 +23,6 @@ def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
         "EnumDerivation": [],
         "PermissibleValueDerivation": [],
     }
-    object_deriv_names: list[str] = []
     derived_from_names: list[str] = []
 
     for cd in specification.class_derivations:
@@ -31,8 +31,6 @@ def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
         for sd in cd.slot_derivations.values():
             if sd.sources:
                 sources_counts["SlotDerivation"].append(sd.name)
-            if sd.object_derivations:
-                object_deriv_names.append(sd.name)
             if sd.derived_from:
                 derived_from_names.append(sd.name)
     for ed in specification.enum_derivations.values():
@@ -54,19 +52,6 @@ def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
                 DeprecationWarning,
                 stacklevel=3,
             )
-
-    if object_deriv_names:
-        names_str = ", ".join(object_deriv_names[:5])
-        suffix = f" (and {len(object_deriv_names) - 5} more)" if len(object_deriv_names) > 5 else ""
-        warnings.warn(
-            f"{len(object_deriv_names)} SlotDerivation(s) use 'object_derivations', "
-            f"which is deprecated: {names_str}{suffix}. "
-            f"Use list-based class_derivations instead. "
-            f"'object_derivations' will be removed in a future version. "
-            f"See https://github.com/linkml/linkml-map/issues/112",
-            DeprecationWarning,
-            stacklevel=3,
-        )
 
     if derived_from_names:
         names_str = ", ".join(derived_from_names[:5])
@@ -100,9 +85,9 @@ def induce_missing_values(specification: TransformationSpecification, source_sch
 
     for cd in specification.class_derivations:
         for sd in cd.slot_derivations.values():
-            if sd.object_derivations:
-                # skip inference for object derivations, inferences come from class derivation later
-                # TODO: we may need to do the inference for the internal class slots
+            if sd.class_derivations:
+                # skip inference for nested class derivations; inferences come from
+                # the class derivation later
                 continue
             # for null mappings, assume that the slot is copied from the same slot in the source
             # TODO: decide if this is the desired behavior

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -371,7 +371,7 @@ class ObjectTransformer(Transformer):
             )
         elif slot_derivation.sources:
             (v, source_class_slot) = self._resolve_sources(slot_derivation, context)
-        elif slot_derivation.object_derivations:
+        elif slot_derivation.class_derivations:
             v = self._derive_nested_objects(slot_derivation, context.source_obj, target_type)
         else:
             source_class_slot = context.sv.induced_slot(slot_derivation.name, context.source_type)
@@ -559,22 +559,17 @@ class ObjectTransformer(Transformer):
         return v, source_class_slot
 
     def _derive_nested_objects(self, slot_derivation: SlotDerivation, source_obj: DICT_OBJ, target_type: str) -> Any:
-        """Build nested objects from explicit object_derivation declarations."""
+        """Build nested objects from slot-level class_derivation declarations."""
         derived_objs = []
 
-        for obj_derivation in slot_derivation.object_derivations:
-            for target_cls, cls_derivation in obj_derivation.class_derivations.items():
-                # Determine the correct source object to use
-                source_sub_obj = source_obj  # You may refine this if needed
-
-                # Recursively map the sub-object
-                nested_result = self.map_object(
-                    source_sub_obj,
-                    source_type=cls_derivation.populated_from,
-                    target_type=target_cls,
-                    class_derivation=cls_derivation,
-                )
-                derived_objs.append(nested_result)
+        for cls_derivation in slot_derivation.class_derivations:
+            nested_result = self.map_object(
+                source_obj,
+                source_type=cls_derivation.populated_from,
+                target_type=cls_derivation.name,
+                class_derivation=cls_derivation,
+            )
+            derived_objs.append(nested_result)
 
         # If the slot is multivalued, we assign the whole list
         # Otherwise, just assign the first (for now; error/warning later if >1)

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -1,6 +1,7 @@
 """Transformers transform objects from one class to another using a transformation specification."""
 
 import logging
+import warnings
 from abc import ABC
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -111,9 +112,7 @@ class Transformer(ABC):
 
     @classmethod
     def normalize_transform_spec(cls, obj: dict[str, Any], normalizer: ReferenceValidator) -> dict:
-        """
-        Recursively normalize class_derivations and their nested object_derivations.
-        """
+        """Recursively normalize class_derivations and flatten object_derivations."""
         obj = normalizer.normalize(obj)
 
         class_derivations = obj.get("class_derivations", [])
@@ -124,29 +123,88 @@ class Transformer(ABC):
         for class_spec in cd_iter:
             if not isinstance(class_spec, dict):
                 continue
+            parent_source = class_spec.get("populated_from")
             slot_derivations = class_spec.get("slot_derivations", {})
-            for slot, slot_spec in slot_derivations.items():
+            for slot_name, slot_spec in slot_derivations.items():
                 if slot_spec.get("value") is not None and slot_spec.get("range") is None:
                     slot_spec["range"] = "string"
-                # Check for nested object_derivations
-                object_derivations = slot_spec.get("object_derivations", [])
-                for i, od in enumerate(object_derivations):
-                    # Recursively normalize each nested class_derivation block
-                    od_normalized = cls.normalize_transform_spec(od, normalizer)
-                    # ObjectDerivation.class_derivations stays as dict (no inlined_as_list),
-                    # but the normalizer may convert it to list. Convert back.
-                    od_cd = od_normalized.get("class_derivations")
-                    if isinstance(od_cd, list):
-                        od_normalized["class_derivations"] = {
-                            item["name"]: item for item in od_cd if isinstance(item, dict)
-                        }
-                    object_derivations[i] = od_normalized
+                cls._normalize_slot_class_derivations(slot_name, slot_spec, normalizer, parent_source)
         return obj
 
     @classmethod
-    def _normalize_spec_dict(cls, obj: dict[str, Any]) -> None:
+    def _normalize_slot_class_derivations(
+        cls,
+        slot_name: str,
+        slot_spec: dict[str, Any],
+        normalizer: ReferenceValidator,
+        parent_populated_from: str | None = None,
+    ) -> None:
+        """Flatten object_derivations and normalize class_derivations on a slot.
+
+        Four steps, applied recursively to nested slots:
+        1. Flatten ``object_derivations`` into ``class_derivations`` (with
+           deprecation warning; error if both are present).
+        2. Expand compact-key entries (``- Condition: {...}`` → ``{name: Condition, ...}``).
+        3. Inherit ``populated_from`` from the parent class derivation when absent.
+        4. Run the normalizer on each class derivation entry so that nested
+           dict-keyed ``slot_derivations`` get ``name`` injected.
         """
-        Normalize a raw specification dict in place.
+        # Step 1: flatten object_derivations → class_derivations
+        object_derivations = slot_spec.get("object_derivations", [])
+        if object_derivations:
+            if slot_spec.get("class_derivations"):
+                msg = (
+                    f"SlotDerivation '{slot_name}' has both 'object_derivations' and "
+                    f"'class_derivations'. Remove 'object_derivations' and use "
+                    f"'class_derivations' only."
+                )
+                raise ValueError(msg)
+
+            warnings.warn(
+                f"SlotDerivation '{slot_name}' uses 'object_derivations', which is "
+                f"deprecated. Use list-based class_derivations instead. "
+                f"'object_derivations' will be removed in a future version. "
+                f"See https://github.com/linkml/linkml-map/issues/112",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+
+            flattened: list[dict[str, Any]] = []
+            for od in object_derivations:
+                od_cd = od.get("class_derivations", {})
+                if isinstance(od_cd, dict):
+                    for name, body in od_cd.items():
+                        entry = body if isinstance(body, dict) else {}
+                        entry.setdefault("name", name)
+                        flattened.append(entry)
+                elif isinstance(od_cd, list):
+                    flattened.extend(od_cd)
+            slot_spec["class_derivations"] = flattened
+            del slot_spec["object_derivations"]
+
+        # Steps 2-4: expand compact keys, inherit populated_from, normalize, and recurse
+        slot_cd = slot_spec.get("class_derivations")
+        if not isinstance(slot_cd, list):
+            return
+
+        cls._expand_compact_keys(slot_cd)
+
+        for cd_entry in slot_cd:
+            if not isinstance(cd_entry, dict):
+                continue
+            if not cd_entry.get("populated_from") and parent_populated_from:
+                cd_entry["populated_from"] = parent_populated_from
+            normalized = normalizer.normalize(cd_entry)
+            cd_entry.clear()
+            cd_entry.update(normalized)
+            child_source = cd_entry.get("populated_from")
+            for nested_name, nested_sd in cd_entry.get("slot_derivations", {}).items():
+                if isinstance(nested_sd, dict):
+                    cls._normalize_slot_class_derivations(nested_name, nested_sd, normalizer, child_source)
+
+    @classmethod
+    def _normalize_spec_dict(cls, obj: dict[str, Any]) -> None:
+        """Normalize a raw specification dict in place.
 
         Bundles _preprocess_class_derivations, ReferenceValidator normalization,
         and nested ObjectDerivation fixup into a single entry point. Mutates
@@ -162,16 +220,29 @@ class Transformer(ABC):
         obj.update(normalized)
 
     @staticmethod
-    def _preprocess_class_derivations(obj: dict[str, Any]) -> None:
+    def _expand_compact_keys(items: list[dict[str, Any]]) -> None:
+        """Expand YAML compact-key dicts in a list in place.
+
+        Converts ``{"Condition": {"populated_from": "x"}}`` →
+        ``{"name": "Condition", "populated_from": "x"}``.
+        Skips items whose sole key is ``"name"`` (already expanded).
         """
-        Pre-process class_derivations before ReferenceValidator normalization.
+        for i, item in enumerate(items):
+            if isinstance(item, dict) and len(item) == 1:
+                key, val = next(iter(item.items()))
+                if key != "name" and isinstance(val, dict | type(None)):
+                    expanded = val if val is not None else {}
+                    expanded.setdefault("name", key)
+                    items[i] = expanded
+
+    @staticmethod
+    def _preprocess_class_derivations(obj: dict[str, Any]) -> None:
+        """Pre-process top-level class_derivations before ReferenceValidator normalization.
 
         Handles two cases:
         1. Dict format with None values (e.g. ``Entity:`` with no body) — replace
            with empty dicts so ReferenceValidator.ensure_list doesn't choke.
-        2. List format with compact keys (e.g. ``- Condition: {populated_from: x}``)
-           — unwrap to ``{name: Condition, populated_from: x}`` so Pydantic can
-           validate.
+        2. List format with compact keys — delegate to ``_expand_compact_keys``.
         """
         cd = obj.get("class_derivations")
         if isinstance(cd, dict):
@@ -179,19 +250,7 @@ class Transformer(ABC):
                 if v is None:
                     cd[k] = {}
         elif isinstance(cd, list):
-            for i, item in enumerate(cd):
-                # Detect YAML compact-key format: a single-key dict where the
-                # key is the class name and the value is the body (dict) or
-                # None.  E.g. ``- Condition: {populated_from: x}`` parses as
-                # ``{"Condition": {"populated_from": "x"}}``.  We skip items
-                # whose sole key is "name" — those are already in expanded
-                # form (``- name: Foo``).
-                if isinstance(item, dict) and len(item) == 1:
-                    key, val = next(iter(item.items()))
-                    if key != "name" and isinstance(val, dict | type(None)):
-                        expanded = val if val is not None else {}
-                        expanded.setdefault("name", key)
-                        cd[i] = expanded
+            Transformer._expand_compact_keys(cd)
 
     def create_transformer_specification(self, obj: dict[str, Any]) -> None:
         """

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -2,6 +2,7 @@
 
 import warnings
 
+import pytest
 from linkml_runtime import SchemaView
 
 from linkml_map.transformer.object_transformer import ObjectTransformer
@@ -169,46 +170,8 @@ def test_sources_on_slot_emits_deprecation_warning():
 
 
 def test_object_derivations_emits_deprecation_warning():
-    """Using object_derivations on a SlotDerivation emits a DeprecationWarning."""
-    source = """\
-id: https://example.org/source
-name: source
-prefixes:
-  linkml: https://w3id.org/linkml/
-imports:
-  - linkml:types
-classes:
-  Person:
-    attributes:
-      name:
-        range: string
-      condition_name:
-        range: string
-"""
-    target = """\
-id: https://example.org/target
-name: target
-prefixes:
-  linkml: https://w3id.org/linkml/
-imports:
-  - linkml:types
-classes:
-  Person:
-    attributes:
-      name:
-        range: string
-      conditions:
-        range: Condition
-        multivalued: true
-        inlined_as_list: true
-  Condition:
-    attributes:
-      name:
-        range: string
-"""
+    """Using object_derivations on a SlotDerivation emits a DeprecationWarning during normalization."""
     tr = ObjectTransformer()
-    tr.source_schemaview = SchemaView(source)
-    tr.target_schemaview = SchemaView(target)
     spec = {
         "class_derivations": {
             "Person": {
@@ -233,16 +196,39 @@ classes:
             },
         },
     }
-    tr.create_transformer_specification(spec)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", DeprecationWarning)
-        _ = tr.derived_specification
+        tr.create_transformer_specification(spec)
 
     deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     od_warnings = [w for w in deprecation_warnings if "object_derivations" in str(w.message)]
     assert len(od_warnings) == 1
     assert "conditions" in str(od_warnings[0].message)
+
+
+def test_object_derivations_and_class_derivations_conflict():
+    """Error if both object_derivations and class_derivations are on the same slot."""
+    spec = {
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {
+                    "conditions": {
+                        "object_derivations": [
+                            {"class_derivations": {"Condition": {"populated_from": "Person"}}},
+                        ],
+                        "class_derivations": [
+                            {"name": "Condition", "populated_from": "Person"},
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    tr = ObjectTransformer()
+    with pytest.raises(ValueError, match="both 'object_derivations' and 'class_derivations'"):
+        tr.create_transformer_specification(spec)
 
 
 def test_no_warning_without_deprecated_fields():

--- a/tests/test_transformer/test_object_transformer.py
+++ b/tests/test_transformer/test_object_transformer.py
@@ -1,5 +1,6 @@
 """Test the object transformer."""
 
+import warnings
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -187,25 +188,43 @@ def test_value_mappings() -> None:
     assert target_dict == TARGET_DATA
 
 
-def test_object_derivations() -> None:
-    """
-    Test nested object_derivations inside slot_derivations using YAML transform spec.
-    """
+NESTED_SOURCE_SLOTS = ["phv00159563", "phv00159568", "phv00159569", "phv00159573", "phv00159578", "phv00159579"]
 
-    # Build source schema
+NESTED_INPUT_DATA = {
+    "phv00159563": "PRESENT",
+    "phv00159568": 123947,
+    "phv00159569": "1",
+    "phv00159573": "ABSENT",
+    "phv00159578": 123947,
+    "phv00159579": "2",
+}
+
+NESTED_EXPECTED_OUTPUT = {
+    "id": 123947,
+    "conditions": [
+        {
+            "condition_concept": "HP:0001681",
+            "condition_status": "PRESENT",
+            "condition_providence": "1",
+        },
+        {
+            "condition_concept": "HP:0001683",
+            "condition_status": "ABSENT",
+            "condition_providence": "2",
+        },
+    ],
+}
+
+
+def _build_nested_schemas():
+    """Build source and target schemas for nested class_derivation tests."""
+    integer_slots = {"phv00159568", "phv00159578"}
     sb_source = SchemaBuilder()
-    sb_source.add_slot("phv00159563", range="string")
-    sb_source.add_slot("phv00159568", range="integer")
-    sb_source.add_slot("phv00159569", range="string")
-    sb_source.add_slot("phv00159573", range="string")
-    sb_source.add_slot("phv00159578", range="integer")
-    sb_source.add_slot("phv00159579", range="string")
-    person_slots = ["phv00159563", "phv00159568", "phv00159569", "phv00159573", "phv00159578", "phv00159579"]
-    sb_source.add_class("Person", slots=person_slots)
+    for slot in NESTED_SOURCE_SLOTS:
+        sb_source.add_slot(slot, range="integer" if slot in integer_slots else "string")
+    sb_source.add_class("Person", slots=NESTED_SOURCE_SLOTS)
     sb_source.add_defaults()
-    source_schema = sb_source.schema
 
-    # Build target schema
     sb_target = SchemaBuilder()
     sb_target.add_slot("id", range="integer")
     sb_target.add_slot("conditions", range="Condition", multivalued=True, inlined=True)
@@ -215,10 +234,56 @@ def test_object_derivations() -> None:
     sb_target.add_class("Participant", slots=["id", "conditions"])
     sb_target.add_class("Condition", slots=["condition_concept", "condition_status", "condition_providence"])
     sb_target.add_defaults()
-    target_schema = sb_target.schema
+    return sb_source.schema, sb_target.schema
 
-    # Transformation spec in YAML
-    transform_spec_yaml = """
+
+def test_nested_class_derivations() -> None:
+    """Test list-based class_derivations on a slot for nested object construction."""
+    source_schema, target_schema = _build_nested_schemas()
+
+    transform_spec = yaml.safe_load("""
+    class_derivations:
+      Participant:
+        populated_from: Person
+        slot_derivations:
+          id:
+            populated_from: phv00159568
+          conditions:
+            class_derivations:
+              - Condition:
+                  populated_from: Person
+                  slot_derivations:
+                    condition_concept:
+                      expr: "'HP:0001681'"
+                    condition_status:
+                      populated_from: phv00159563
+                    condition_providence:
+                      populated_from: phv00159569
+              - Condition:
+                  populated_from: Person
+                  slot_derivations:
+                    condition_concept:
+                      expr: "'HP:0001683'"
+                    condition_status:
+                      populated_from: phv00159573
+                    condition_providence:
+                      populated_from: phv00159579
+    """)
+
+    transformer = ObjectTransformer(unrestricted_eval=True)
+    transformer.source_schemaview = SchemaView(source_schema)
+    transformer.target_schemaview = SchemaView(target_schema)
+    transformer.create_transformer_specification(transform_spec)
+
+    result = transformer.map_object(NESTED_INPUT_DATA, source_type="Person")
+    assert result == NESTED_EXPECTED_OUTPUT
+
+
+def test_object_derivations_backward_compat() -> None:
+    """Deprecated object_derivations still work via normalization to class_derivations."""
+    source_schema, target_schema = _build_nested_schemas()
+
+    transform_spec = yaml.safe_load("""
     class_derivations:
       Participant:
         populated_from: Person
@@ -247,46 +312,61 @@ def test_object_derivations() -> None:
                         populated_from: phv00159573
                       condition_providence:
                         populated_from: phv00159579
-    """
+    """)
 
-    transform_spec = yaml.safe_load(transform_spec_yaml)
+    transformer = ObjectTransformer(unrestricted_eval=True)
+    transformer.source_schemaview = SchemaView(source_schema)
+    transformer.target_schemaview = SchemaView(target_schema)
 
-    # Source input
-    input_data = {
-        "phv00159563": "PRESENT",
-        "phv00159568": 123947,
-        "phv00159569": "1",
-        "phv00159573": "ABSENT",
-        "phv00159578": 123947,
-        "phv00159579": "2",
-    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        transformer.create_transformer_specification(transform_spec)
 
-    # Expected target output
-    expected_output = {
-        "id": 123947,
-        "conditions": [
-            {
-                "condition_concept": "HP:0001681",
-                "condition_status": "PRESENT",
-                "condition_providence": "1",
-            },
-            {
-                "condition_concept": "HP:0001683",
-                "condition_status": "ABSENT",
-                "condition_providence": "2",
-            },
-        ],
-    }
+    od_warnings = [w for w in caught if "object_derivations" in str(w.message)]
+    assert len(od_warnings) >= 1
 
-    # Create ObjectTransformer and apply transformation
+    result = transformer.map_object(NESTED_INPUT_DATA, source_type="Person")
+    assert result == NESTED_EXPECTED_OUTPUT
+
+
+def test_nested_class_derivations_inherit_populated_from() -> None:
+    """Nested class_derivations inherit populated_from from their parent when omitted."""
+    source_schema, target_schema = _build_nested_schemas()
+
+    transform_spec = yaml.safe_load("""
+    class_derivations:
+      Participant:
+        populated_from: Person
+        slot_derivations:
+          id:
+            populated_from: phv00159568
+          conditions:
+            class_derivations:
+              - Condition:
+                  slot_derivations:
+                    condition_concept:
+                      expr: "'HP:0001681'"
+                    condition_status:
+                      populated_from: phv00159563
+                    condition_providence:
+                      populated_from: phv00159569
+              - Condition:
+                  slot_derivations:
+                    condition_concept:
+                      expr: "'HP:0001683'"
+                    condition_status:
+                      populated_from: phv00159573
+                    condition_providence:
+                      populated_from: phv00159579
+    """)
+
     transformer = ObjectTransformer(unrestricted_eval=True)
     transformer.source_schemaview = SchemaView(source_schema)
     transformer.target_schemaview = SchemaView(target_schema)
     transformer.create_transformer_specification(transform_spec)
 
-    result = transformer.map_object(input_data, source_type="Person")
-
-    assert result == expected_output
+    result = transformer.map_object(NESTED_INPUT_DATA, source_type="Person")
+    assert result == NESTED_EXPECTED_OUTPUT
 
 
 def test_transform_simple_object(obj_tr: ObjectTransformer) -> None:


### PR DESCRIPTION
## Summary

- Add `class_derivations` to `SlotDerivation` as the direct replacement for `object_derivations`
- Normalization flattens `object_derivations` → `class_derivations` with deprecation warning; errors if both present
- Nested `class_derivations` inherit `populated_from` from their parent when unspecified, eliminating redundant source declarations in deeply nested specs (e.g., MeasurementObservationSet → MeasurementObservation → Quantity)
- Remove `object_derivations` from the transformer execution path — only `class_derivations` is checked at runtime

## Before / After

```yaml
# Before (object_derivations):
slot_derivations:
  conditions:
    object_derivations:
      - class_derivations:
          Condition:
            populated_from: Person
            slot_derivations: ...

# After (class_derivations with inherited populated_from):
slot_derivations:
  conditions:
    class_derivations:
      - Condition:
          slot_derivations: ...  # inherits populated_from from parent
```

## Test plan

- [x] New: `test_nested_class_derivations` — verifies slot-level class_derivations
- [x] New: `test_nested_class_derivations_inherit_populated_from` — verifies populated_from inheritance
- [x] New: `test_object_derivations_backward_compat` — old specs still work via normalization
- [x] New: `test_object_derivations_and_class_derivations_conflict` — errors when both present
- [x] Updated: `test_object_derivations_emits_deprecation_warning` — warning now fires during normalization
- [x] All 589 tests pass (534 unit + 55 compliance)
- [x] Ruff clean

Closes #112