### PR TITLE
Deprecate top-level slot_derivations on TransformationSpecification

### DIFF
--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -191,7 +191,13 @@ class TransformationSpecification(SpecificationComponent):
     content_url: Optional[str] = Field(default=None, description="""Reference to the actual content of the mapping specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     class_derivations: Optional[list[ClassDerivation]] = Field(default_factory=list, description="""Instructions on how to derive a set of classes in the target schema from classes in the source schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ObjectDerivation']} })
     enum_derivations: Optional[dict[str, EnumDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of enums in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
-    slot_derivations: Optional[dict[str, SlotDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of top level slots in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ClassDerivation']} })
+    slot_derivations: Optional[dict[str, SlotDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of top level slots in the target schema""", json_schema_extra = { "linkml_meta": {'deprecated': 'Not implemented. Top-level slot derivations lack deterministic '
+                       "semantics because a slot's derivation depends on the class "
+                       'context in which it appears — the same slot may need different '
+                       'derivations in different classes. Use slot_derivations within '
+                       'each ClassDerivation instead. See '
+                       'https://github.com/linkml/linkml-map/issues/47',
+         'domain_of': ['TransformationSpecification', 'ClassDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -160,6 +160,12 @@ classes:
         range: SlotDerivation
         multivalued: true
         inlined: true
+        deprecated: >-
+          Not implemented. Top-level slot derivations lack deterministic semantics
+          because a slot's derivation depends on the class context in which it
+          appears — the same slot may need different derivations in different
+          classes. Use slot_derivations within each ClassDerivation instead.
+          See https://github.com/linkml/linkml-map/issues/47
 
   ElementDerivation:
     is_a: SpecificationComponent


### PR DESCRIPTION
## Summary

- Deprecates `slot_derivations` on `TransformationSpecification` — it was never implemented and lacks deterministic semantics since a slot's derivation depends on the class context in which it appears
- `slot_derivations` within `ClassDerivation` is unaffected
- Regenerated `transformer_model.py` from updated YAML

## Context

Top-level slot derivations look like they should work (the field exists in the model), but there's no meaningful way to implement them — the same slot may need different derivations in different classes. The deprecation message explains this directly in the model for anyone who encounters the field.

Doc rendering of the deprecation message is blocked on upstream linkml/linkml#3445 (gen-doc templates discard deprecation text and don't support per-class attribute deprecation).

Closes #47

## Test plan

- [ ] Existing tests pass (no runtime behavior change)
- [ ] Verify deprecation appears in YAML model and generated Python