### PR TITLE
Fix LookupIndex delimiter misdetection on sparse TSVs

### DIFF
--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import duckdb
 
+from linkml_map.loaders.data_loaders import FileFormat
+
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _HAS_DIGIT_RE = re.compile(r"[0-9]")
 
@@ -44,6 +46,9 @@ class LookupIndex:
 
     Each registered table is loaded from a CSV/TSV file via ``read_csv_auto``
     and indexed on a key column for fast single-row lookups.
+
+    Delimiter detection uses :class:`~linkml_map.loaders.data_loaders.FileFormat`
+    so that file parsing is consistent with :class:`~linkml_map.loaders.data_loaders.DataLoader`.
     """
 
     def __init__(self) -> None:
@@ -62,10 +67,12 @@ class LookupIndex:
         _validate_identifier(name)
         _validate_identifier(key_column)
         file_path = Path(file_path)
+        fmt = FileFormat.from_extension(file_path)
+        delim = {FileFormat.TSV: "\t", FileFormat.CSV: ","}[fmt]
         self._conn.execute(
             f"CREATE OR REPLACE TABLE {name} AS "  # noqa: S608
-            "SELECT * FROM read_csv_auto(?, all_varchar=true)",
-            [str(file_path)],
+            "SELECT * FROM read_csv_auto(?, all_varchar=true, delim=?, null_padding=true)",
+            [str(file_path), delim],
         )
         self._conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{name}_{key_column} ON {name} ({key_column})"  # noqa: S608

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -40,14 +40,31 @@ def _validate_identifier(name: str) -> None:
         raise ValueError(msg)
 
 
+def _duckdb_read_expr(fmt: FileFormat) -> str:
+    """Return a DuckDB ``SELECT ... FROM read_*()`` expression for *fmt*.
+
+    The returned SQL contains a single ``?`` placeholder for the file path.
+
+    :raises NotImplementedError: For formats without DuckDB reader support.
+    """
+    if fmt == FileFormat.TSV:
+        return "SELECT * FROM read_csv_auto(?, all_varchar=true, delim='\t', null_padding=true)"
+    if fmt == FileFormat.CSV:
+        return "SELECT * FROM read_csv_auto(?, all_varchar=true, delim=',', null_padding=true)"
+    if fmt == FileFormat.JSON:
+        return "SELECT CAST(columns(*) AS VARCHAR) FROM read_json_auto(?)"
+    msg = f"LookupIndex does not yet support {fmt.value!r} files"
+    raise NotImplementedError(msg)
+
+
 class LookupIndex:
     """
     In-memory DuckDB index for cross-table lookups.
 
-    Each registered table is loaded from a CSV/TSV file via ``read_csv_auto``
-    and indexed on a key column for fast single-row lookups.
+    Each registered table is loaded from a CSV, TSV, or JSON file and indexed
+    on a key column for fast single-row lookups.
 
-    Delimiter detection uses :class:`~linkml_map.loaders.data_loaders.FileFormat`
+    Format detection uses :class:`~linkml_map.loaders.data_loaders.FileFormat`
     so that file parsing is consistent with :class:`~linkml_map.loaders.data_loaders.DataLoader`.
     """
 
@@ -58,21 +75,23 @@ class LookupIndex:
 
     def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
         """
-        Load a CSV/TSV file into DuckDB and create an index on *key_column*.
+        Load a data file into DuckDB and create an index on *key_column*.
+
+        Supported formats: CSV, TSV, JSON (auto-detected from file extension
+        via :class:`~linkml_map.loaders.data_loaders.FileFormat`).
 
         :param name: Logical table name (must be a valid identifier).
-        :param file_path: Path to a CSV or TSV file.
+        :param file_path: Path to a data file.
         :param key_column: Column to index for lookups.
+        :raises NotImplementedError: If the file format is not yet supported (e.g. YAML).
         """
         _validate_identifier(name)
         _validate_identifier(key_column)
         file_path = Path(file_path)
         fmt = FileFormat.from_extension(file_path)
-        delim = {FileFormat.TSV: "\t", FileFormat.CSV: ","}[fmt]
         self._conn.execute(
-            f"CREATE OR REPLACE TABLE {name} AS "  # noqa: S608
-            "SELECT * FROM read_csv_auto(?, all_varchar=true, delim=?, null_padding=true)",
-            [str(file_path), delim],
+            f"CREATE OR REPLACE TABLE {name} AS {_duckdb_read_expr(fmt)}",  # noqa: S608
+            [str(file_path)],
         )
         self._conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{name}_{key_column} ON {name} ({key_column})"  # noqa: S608

--- a/tests/test_cli/test_cli_validate.py
+++ b/tests/test_cli/test_cli_validate.py
@@ -16,14 +16,16 @@ def test_validate_spec_valid_file(runner: CliRunner) -> None:
     """A valid trans-spec file exits 0 and prints ok."""
     result = runner.invoke(main, ["validate-spec", str(FLATTENING_TR)])
     assert result.exit_code == 0
-    assert "ok" in result.output
+    assert result.output.strip().endswith(": ok")
 
 
 def test_validate_spec_multiple_files(runner: CliRunner) -> None:
     """Multiple valid files all report ok."""
     result = runner.invoke(main, ["validate-spec", str(FLATTENING_TR), str(PERSONINFO_TR)])
     assert result.exit_code == 0
-    assert result.output.count("ok") == 2
+    lines = result.output.splitlines()
+    assert lines
+    assert all(line.endswith(": ok") for line in lines)
 
 
 def test_validate_spec_invalid_file(runner: CliRunner, tmp_path) -> None:
@@ -50,7 +52,7 @@ def test_validate_spec_mixed_valid_invalid(runner: CliRunner, tmp_path) -> None:
     bad.write_text("bogus_field: 123\n")
     result = runner.invoke(main, ["validate-spec", str(FLATTENING_TR), str(bad)])
     assert result.exit_code == 1
-    assert "ok" in result.output
+    assert any(line.endswith(": ok") for line in result.output.splitlines())
     assert "bogus_field" in result.stderr
 
 

--- a/tests/test_utils/test_lookup_index.py
+++ b/tests/test_utils/test_lookup_index.py
@@ -2,6 +2,8 @@
 
 # ruff: noqa: ANN401
 
+import json
+
 import pytest
 
 from linkml_map.utils.lookup_index import LookupIndex
@@ -82,6 +84,29 @@ def test_numeric_coercion(index, tmp_path):
     assert row is not None
     assert row["count"] == 42
     assert isinstance(row["count"], int)
+
+
+def test_json_format(index, tmp_path):
+    """JSON files containing a flat array of objects can be registered and queried."""
+    data = [
+        {"id": "J1", "name": "Alice", "age": "30"},
+        {"id": "J2", "name": "Bob", "age": "25"},
+    ]
+    jf = tmp_path / "data.json"
+    jf.write_text(json.dumps(data))
+    index.register_table("jdata", jf, "id")
+    row = index.lookup_row("jdata", "id", "J2")
+    assert row is not None
+    assert row["name"] == "Bob"
+    assert row["age"] == 25
+
+
+def test_yaml_format_not_implemented(index, tmp_path):
+    """YAML files raise NotImplementedError with a clear message."""
+    yf = tmp_path / "data.yaml"
+    yf.write_text("- id: Y1\n  name: Alice\n")
+    with pytest.raises(NotImplementedError, match="yaml"):
+        index.register_table("ydata", yf, "id")
 
 
 def test_sparse_tsv_many_columns(index, tmp_path):

--- a/tests/test_utils/test_lookup_index.py
+++ b/tests/test_utils/test_lookup_index.py
@@ -82,3 +82,26 @@ def test_numeric_coercion(index, tmp_path):
     assert row is not None
     assert row["count"] == 42
     assert isinstance(row["count"], int)
+
+
+def test_sparse_tsv_many_columns(index, tmp_path):
+    """Sparse TSV with many columns and few populated fields loads correctly.
+
+    Reproduces the bug from issue #209: DuckDB's read_csv_auto misdetects the
+    delimiter when a TSV has many columns but sparse data rows, collapsing the
+    entire header into a single column name.
+    """
+    cols = ["subject_id"] + [f"phv{i:08d}" for i in range(1, 201)]
+    tsv = tmp_path / "sparse.tsv"
+    header = "\t".join(cols)
+    row = "SUBJ001\t65\tfoo"  # 3 values, 201 columns
+    tsv.write_text(f"{header}\n{row}\n")
+
+    index.register_table("sparse", tsv, "subject_id")
+    result = index.lookup_row("sparse", "subject_id", "SUBJ001")
+    assert result is not None
+    assert result["subject_id"] == "SUBJ001"
+    assert result["phv00000001"] == 65
+    assert result["phv00000002"] == "foo"
+    # Unpopulated columns should be None (null-padded)
+    assert result["phv00000003"] is None


### PR DESCRIPTION
## Summary
- Derive delimiter from `FileFormat.from_extension()` instead of relying on DuckDB's `read_csv_auto` heuristic, which fails when a TSV has many columns but sparse data rows
- Enable `null_padding=true` to match `DataLoader`/`DictReader` behavior on rows with fewer fields than columns
- Both file-loading paths (`DataLoader` and `LookupIndex`) now use `FileFormat` as the single source of truth for format detection

Fixes #209

## Test plan
- [x] New `test_sparse_tsv_many_columns` reproduces the original bug (201 columns, 3 populated fields)
- [x] All 17 lookup_index tests pass
- [x] Full test suite passes (589 passed, 4 skipped)