### PR TITLE
Replace `source_schema` / `target_schema` strings with `SchemaReference`

### DIFF
--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -234,7 +234,7 @@ class SchemaReference(ConfiguredBaseModel):
                        'PermissibleValueDerivation',
                        'Agent']} })
     version: Optional[str] = Field(default=None, description="""Version string for the schema (e.g. semver or date-based).""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'SchemaReference', 'Software'],
-         'slot_uri': 'dcterms:hasVersion'} })
+         'slot_uri': 'schema:version'} })
     schema_uri: Optional[str] = Field(default=None, description="""The URI/IRI identifier of the schema (matches the schema's `id`).""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference']} })
     source_file: Optional[str] = Field(default=None, description="""Optional file path or URL from which the schema can be loaded.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference']} })
 

--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -176,12 +176,12 @@ class TransformationSpecification(SpecificationComponent):
     title: Optional[str] = Field(default=None, description="""human readable title for this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'dcterms:title'} })
     publication_date: Optional[date] = Field(default=None, description="""date of publication of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'dcterms:issued'} })
     license: Optional[str] = Field(default=None, description="""license under which this transformation specification is published""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'dcterms:license'} })
-    version: Optional[str] = Field(default=None, description="""version of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Software'],
+    version: Optional[str] = Field(default=None, description="""version of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'SchemaReference', 'Software'],
          'slot_uri': 'dcterms:version'} })
     prefixes: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""maps prefixes to URL expansions""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'sh:declare'} })
     copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
-    source_schema: Optional[str] = Field(default=None, description="""name of the schema that describes the source (input) objects""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
-    target_schema: Optional[str] = Field(default=None, description="""name of the schema that describes the target (output) objects""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
+    source_schema: Optional[SchemaReference] = Field(default=None, description="""Reference to the schema that describes the source (input) objects.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
+    target_schema: Optional[SchemaReference] = Field(default=None, description="""Reference to the schema that describes the target (output) objects.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     source_schema_patches: Optional[Any] = Field(default=None, description="""Schema patches to apply to the source schema before transformation. Useful for adding foreign key relationships to auto-generated schemas. Uses LinkML schema YAML structure (classes, slots, attributes, etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     creator: Optional[list[Union[Agent,Person,Organization,Software]]] = Field(default_factory=list, description="""A list of creators of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'dcterms:creator'} })
     author: Optional[list[Union[Agent,Person,Organization,Software]]] = Field(default_factory=list, description="""A list of authors of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
@@ -220,13 +220,33 @@ class TransformationSpecification(SpecificationComponent):
         return v
 
 
+class SchemaReference(ConfiguredBaseModel):
+    """
+    A reference to a LinkML schema, with optional version and locator metadata. Used by `source_schema` and `target_schema` on `TransformationSpecification`.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
+
+    name: str = Field(default=..., description="""The name or identifier of the schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
+                       'ObjectDerivation',
+                       'SlotDerivation',
+                       'EnumDerivation',
+                       'PermissibleValueDerivation',
+                       'Agent']} })
+    version: Optional[str] = Field(default=None, description="""Version string for the schema (e.g. semver or date-based).""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'SchemaReference', 'Software'],
+         'slot_uri': 'dcterms:hasVersion'} })
+    schema_uri: Optional[str] = Field(default=None, description="""The URI/IRI identifier of the schema (matches the schema's `id`).""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference']} })
+    source_file: Optional[str] = Field(default=None, description="""Optional file path or URL from which the schema can be loaded.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference']} })
+
+
 class ElementDerivation(SpecificationComponent):
     """
     An abstract grouping for classes that provide a specification of how to derive a target element from a source element.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -273,7 +293,8 @@ class ClassDerivation(ElementDerivation):
     target_definition: Optional[Any] = Field(default=None, description="""LinkML class definition object for this slot.""", json_schema_extra = { "linkml_meta": {'comments': ['currently defined as Any to avoid coupling with metamodel'],
          'domain_of': ['ClassDerivation', 'SlotDerivation']} })
     pivot_operation: Optional[PivotOperation] = Field(default=None, description="""Configuration for pivot (unmelt) operations at class level""", json_schema_extra = { "linkml_meta": {'domain_of': ['ClassDerivation', 'SlotDerivation']} })
-    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -304,7 +325,8 @@ class ObjectDerivation(ElementDerivation):
                        'https://github.com/linkml/linkml-map/issues/112',
          'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    name: Optional[str] = Field(default=None, description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: Optional[str] = Field(default=None, description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -348,7 +370,8 @@ class SlotDerivation(ElementDerivation):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    name: str = Field(default=..., description="""Target slot name""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Target slot name""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -417,7 +440,8 @@ class EnumDerivation(ElementDerivation):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    name: str = Field(default=..., description="""Target enum name""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Target enum name""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -466,7 +490,8 @@ class PermissibleValueDerivation(ElementDerivation):
          'todos': ['this is currently under-specified. We will need boolean '
                    'combinators to express if-then-else']})
 
-    name: str = Field(default=..., description="""Target permissible value text""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Target permissible value text""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -509,7 +534,8 @@ class PermissibleValueDerivation(ElementDerivation):
 class PrefixDerivation(ElementDerivation):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -632,7 +658,8 @@ class Agent(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True, 'from_schema': 'https://w3id.org/linkml/transformer'})
 
     id: str = Field(default=..., description="""Identifier for the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Agent']} })
-    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -651,7 +678,8 @@ class Person(Agent):
     orcid: Optional[str] = Field(default=None, description="""ORCID identifier for the person""", json_schema_extra = { "linkml_meta": {'domain_of': ['Person']} })
     affiliation: Optional[str] = Field(default=None, description="""Institutional affiliation of the person""", json_schema_extra = { "linkml_meta": {'domain_of': ['Person']} })
     id: str = Field(default=..., description="""Identifier for the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Agent']} })
-    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -670,7 +698,8 @@ class Organization(Agent):
     ror_id: Optional[str] = Field(default=None, description="""ROR (Research Organization Registry) identifier""", json_schema_extra = { "linkml_meta": {'domain_of': ['Organization']} })
     url: Optional[str] = Field(default=None, description="""URL or web address of the organization""", json_schema_extra = { "linkml_meta": {'domain_of': ['Organization']} })
     id: str = Field(default=..., description="""Identifier for the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Agent']} })
-    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -686,10 +715,11 @@ class Software(Agent):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    version: Optional[str] = Field(default=None, description="""Version of the software""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Software']} })
+    version: Optional[str] = Field(default=None, description="""Version of the software""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'SchemaReference', 'Software']} })
     repository_url: Optional[str] = Field(default=None, description="""URL to a code repository""", json_schema_extra = { "linkml_meta": {'domain_of': ['Software']} })
     id: str = Field(default=..., description="""Identifier for the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'Agent']} })
-    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation',
+    name: Optional[str] = Field(default=None, description="""Name of the agent""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
+                       'ElementDerivation',
                        'ObjectDerivation',
                        'SlotDerivation',
                        'EnumDerivation',
@@ -723,6 +753,7 @@ As of now there it is under-specified, how to specify the sub-elements to includ
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 SpecificationComponent.model_rebuild()
 TransformationSpecification.model_rebuild()
+SchemaReference.model_rebuild()
 ElementDerivation.model_rebuild()
 ClassDerivation.model_rebuild()
 ObjectDerivation.model_rebuild()

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -101,10 +101,14 @@ classes:
         inlined: true
       source_schema:
         # Corresponds to fair_mappings_schema:MappingSpecification.subject_source
-        description: name of the schema that describes the source (input) objects
+        range: SchemaReference
+        inlined: true
+        description: Reference to the schema that describes the source (input) objects.
       target_schema:
         # Corresponds to fair_mappings_schema:MappingSpecification.object_source
-        description: name of the schema that describes the target (output) objects
+        range: SchemaReference
+        inlined: true
+        description: Reference to the schema that describes the target (output) objects.
       source_schema_patches:
         range: Any
         description: >-
@@ -166,6 +170,28 @@ classes:
           appears — the same slot may need different derivations in different
           classes. Use slot_derivations within each ClassDerivation instead.
           See https://github.com/linkml/linkml-map/issues/47
+
+  SchemaReference:
+    description: >-
+      A reference to a LinkML schema, with optional version and locator
+      metadata. Used by `source_schema` and `target_schema` on
+      `TransformationSpecification`.
+    attributes:
+      name:
+        description: The name or identifier of the schema.
+        range: string
+        required: true
+      version:
+        description: Version string for the schema (e.g. semver or date-based).
+        range: string
+        slot_uri: dcterms:hasVersion
+      schema_uri:
+        description: The URI/IRI identifier of the schema (matches the schema's `id`).
+        range: uri
+      source_file:
+        description: >-
+          Optional file path or URL from which the schema can be loaded.
+        range: string
 
   ElementDerivation:
     is_a: SpecificationComponent

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -184,7 +184,7 @@ classes:
       version:
         description: Version string for the schema (e.g. semver or date-based).
         range: string
-        slot_uri: dcterms:hasVersion
+        slot_uri: schema:version
       schema_uri:
         description: The URI/IRI identifier of the schema (matches the schema's `id`).
         range: uri

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -272,23 +272,22 @@ def _load_schemaview_with_timeout(path: str, timeout: int = _SCHEMA_LOAD_TIMEOUT
 
 
 def _resolve_schema_path(
-    spec_value: str | dict | None,
+    spec_value: dict | None,
     explicit: str | Path | None,
     base_path: Path | None,
 ) -> tuple[str | None, bool]:
     """Resolve a schema path from explicit argument or spec field.
 
-    Auto-detection from a spec value supports **local file paths** (relative
-    to the spec file or absolute) and **URLs** (any value containing
-    ``://``). Identifier-style values (e.g. ``source_schema: biolink``) are
-    *not* auto-resolved — pass ``--source-schema`` / ``--target-schema``
-    explicitly to point at a real file or URL for those cases. Skipping
-    silently here prevents typos from triggering surprise network requests
-    during validation.
+    Auto-detection reads ``source_file`` (preferred) or ``name`` from the
+    ``SchemaReference`` and supports **local file paths** (relative to the
+    spec file or absolute) and **URLs** (any value containing ``://``).
+    Identifier-style values (e.g. ``name: biolink``) are *not* auto-resolved
+    — pass ``--source-schema`` / ``--target-schema`` explicitly to point at
+    a real file or URL for those cases. Skipping silently here prevents typos
+    from triggering surprise network requests during validation.
 
     :param spec_value: The ``source_schema`` or ``target_schema`` value from
-        the spec. May be a ``SchemaReference`` dict (current schema form) or
-        a plain string (legacy form, still accepted by this resolver).
+        the normalized spec — a ``SchemaReference`` dict.
     :param explicit: An explicitly provided schema path (overrides spec_value).
     :param base_path: Directory to resolve relative paths against (typically
         the directory containing the spec file).
@@ -299,30 +298,25 @@ def _resolve_schema_path(
         return str(explicit), True
     if spec_value is None:
         return None, False
-    # `source_schema` / `target_schema` are SchemaReference objects; prefer
-    # `source_file` (explicit locator) and fall back to `name` for back-compat
-    # with specs that still use the bare-string form.
-    if isinstance(spec_value, dict):
-        locator = spec_value.get("source_file") or spec_value.get("name")
-        if locator is None:
-            return None, False
-        spec_value = locator
+    locator = spec_value.get("source_file") or spec_value.get("name")
+    if locator is None:
+        return None, False
     # Try relative to spec file directory
     if base_path is not None:
-        candidate = base_path / spec_value
+        candidate = base_path / locator
         if candidate.exists():
             return str(candidate), False
     # Try as-is (absolute path)
-    if Path(spec_value).exists():
-        return spec_value, False
+    if Path(locator).exists():
+        return locator, False
     # URLs: let SchemaView attempt resolution with a timeout
-    if "://" in spec_value:
-        return spec_value, False
+    if "://" in locator:
+        return locator, False
     # Identifier-style values (no path, no URL): skip auto-detection.
     logger.debug(
         "Schema value %r is neither a resolvable path nor a URL; skipping auto-detection. "
         "Pass --source-schema / --target-schema to validate against this schema.",
-        spec_value,
+        locator,
     )
     return None, False
 

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -265,7 +265,7 @@ def _load_schemaview_with_timeout(path: str, timeout: int = _SCHEMA_LOAD_TIMEOUT
 
 
 def _resolve_schema_path(
-    spec_value: str | None,
+    spec_value: str | dict | None,
     explicit: str | Path | None,
     base_path: Path | None,
 ) -> tuple[str | None, bool]:
@@ -279,7 +279,9 @@ def _resolve_schema_path(
     silently here prevents typos from triggering surprise network requests
     during validation.
 
-    :param spec_value: The ``source_schema`` or ``target_schema`` value from the spec.
+    :param spec_value: The ``source_schema`` or ``target_schema`` value from
+        the spec. May be a ``SchemaReference`` dict (current schema form) or
+        a plain string (legacy form, still accepted by this resolver).
     :param explicit: An explicitly provided schema path (overrides spec_value).
     :param base_path: Directory to resolve relative paths against (typically
         the directory containing the spec file).
@@ -290,6 +292,14 @@ def _resolve_schema_path(
         return str(explicit), True
     if spec_value is None:
         return None, False
+    # `source_schema` / `target_schema` are SchemaReference objects; prefer
+    # `source_file` (explicit locator) and fall back to `name` for back-compat
+    # with specs that still use the bare-string form.
+    if isinstance(spec_value, dict):
+        locator = spec_value.get("source_file") or spec_value.get("name")
+        if locator is None:
+            return None, False
+        spec_value = locator
     # Try relative to spec file directory
     if base_path is not None:
         candidate = base_path / spec_value

--- a/tests/input/examples/biolink/transform/biolink-example-profile.transform.yaml
+++ b/tests/input/examples/biolink/transform/biolink-example-profile.transform.yaml
@@ -2,8 +2,10 @@ id: example-biolink-profile
 title: Example Biolink Profile
 prefixes:
   biolink: https://w3id.org/biolink/vocab/
-source_schema: biolink
-target_schema: monarch
+source_schema:
+  name: biolink
+target_schema:
+  name: monarch
 
 #slot_names_match: true    # autopopulates slot.populated_from
 #class_names_match: true   # autopopulates class.populated_from

--- a/tests/input/examples/fair_mappings_metadata/data/sample-linkmlmap-spec.yaml
+++ b/tests/input/examples/fair_mappings_metadata/data/sample-linkmlmap-spec.yaml
@@ -44,9 +44,11 @@ reviewer:
     id: orcid:0000-0001-1111-2222
     name: Alice Johnson
 
-# source_schema and target_schema (simple strings in linkml-map)
-source_schema: legacy_gene_expression.yaml
-target_schema: biolink_model.yaml
+# source_schema and target_schema (SchemaReference objects in linkml-map)
+source_schema:
+  name: legacy_gene_expression.yaml
+target_schema:
+  name: biolink_model.yaml
 
 # ============================================================================
 # ACTUAL TRANSFORMATION CONTENT (commented out due to dynamic_object bug)

--- a/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
+++ b/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
@@ -52,11 +52,16 @@ class_derivations:
       reviewer:
         populated_from: reviewer
       subject_source:
-        expr: "{'name': source_schema}"
-        description: Maps source_schema string to a Source object with name field
+        expr: "{'name': source_schema.name}"
+        description: |-
+          Maps source_schema (a SchemaReference) to a Source object,
+          extracting `.name`. Other fields (`schema_version`, `schema_uri`,
+          `source_file`) can be added here if needed downstream.
       object_source:
-        expr: "{'name': target_schema}"
-        description: Maps target_schema string to a Source object with name field
+        expr: "{'name': target_schema.name}"
+        description: |-
+          Maps target_schema (a SchemaReference) to a Source object,
+          extracting `.name`.
 
   Agent:
     populated_from: Agent

--- a/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
+++ b/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
@@ -10,7 +10,8 @@ prefixes:
   linkmlmap: https://w3id.org/linkml/transformer/
   fair_mappings_schema: https://w3id.org/mapping-commons/fair-mappings-schema/
 
-source_schema: src/linkml_map/datamodel/transformer_model.yaml
+source_schema:
+  name: src/linkml_map/datamodel/transformer_model.yaml
 # Note: target_schema should point to a local checkout of fair-mappings-schema
 # The transformation will still work without the target schema, but with warnings
 # target_schema: path/to/fair-mappings-schema/src/fair_mappings_schema/schema/fair_mappings_schema.yaml

--- a/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
+++ b/tests/input/examples/fair_mappings_metadata/transform/linkmlmap-to-fair.transformation.yaml
@@ -55,7 +55,7 @@ class_derivations:
         expr: "{'name': source_schema.name}"
         description: |-
           Maps source_schema (a SchemaReference) to a Source object,
-          extracting `.name`. Other fields (`schema_version`, `schema_uri`,
+          extracting `.name`. Other fields (`version`, `schema_uri`,
           `source_file`) can be added here if needed downstream.
       object_source:
         expr: "{'name': target_schema.name}"

--- a/tests/input/examples/flattening/transform/denormalize.transform.yaml
+++ b/tests/input/examples/flattening/transform/denormalize.transform.yaml
@@ -2,8 +2,10 @@ id: denormalize-mapping
 title: denormalize mappings
 prefixes:
   foo: foo
-source_schema: s1
-target_schema: s2
+source_schema:
+  name: s1
+target_schema:
+  name: s2
 class_derivations:
   MappingSet:
     populated_from: MappingSet

--- a/tests/input/examples/personinfo_basic/transform/personinfo-to-agent.transform.yaml
+++ b/tests/input/examples/personinfo_basic/transform/personinfo-to-agent.transform.yaml
@@ -13,8 +13,10 @@ creator:
 author:
   - id: https://orcid.org/0000-0002-7356-1779
 publication_date: 2025-08-14
-source_schema: https://w3id.org/linkml/map/example/personinfo.yaml
-target_schema: https://w3id.org/linkml/map/example/agent.yaml
+source_schema:
+  name: https://w3id.org/linkml/map/example/personinfo.yaml
+target_schema:
+  name: https://w3id.org/linkml/map/example/agent.yaml
 mapping_method: semapv:ManualMappingCuration
 class_derivations:
   Container:

--- a/tests/scaffold/transform/person_to_agent.transform.yaml
+++ b/tests/scaffold/transform/person_to_agent.transform.yaml
@@ -3,8 +3,10 @@ title: Minimal scaffold mapping
 prefixes:
   src: https://example.org/test-source-scaffold/
   tgt: https://example.org/test-target-scaffold/
-source_schema: https://example.org/test-source-scaffold
-target_schema: https://example.org/test-target-scaffold
+source_schema:
+  name: https://example.org/test-source-scaffold
+target_schema:
+  name: https://example.org/test-target-scaffold
 
 class_derivations:
   Agent:

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -397,12 +397,12 @@ def test_schema_reference_yaml_object_form_loads(tmp_path) -> None:
 id: structured-spec
 source_schema:
   name: personinfo
-  version: 1.0
+  version: '1.0'
   schema_uri: https://w3id.org/linkml/map/example/personinfo.yaml
   source_file: schemas/personinfo.yaml
 target_schema:
   name: agent
-  version: 2.0
+  version: '2.0'
 """
     spec_path = tmp_path / "spec.yaml"
     spec_path.write_text(yaml_str)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -7,6 +7,7 @@ from linkml_map.datamodel.transformer_model import (
     ClassDerivation,
     Organization,
     Person,
+    SchemaReference,
     SlotDerivation,
     TransformationSpecification,
 )
@@ -20,8 +21,8 @@ def test_datamodel() -> None:
     tr.load_transformer_specification(PERSONINFO_TR)
     trs = tr.specification
     assert trs.model_dump_json() != ""
-    assert trs.source_schema == "https://w3id.org/linkml/map/example/personinfo.yaml"
-    assert trs.target_schema == "https://w3id.org/linkml/map/example/agent.yaml"
+    assert trs.source_schema.name == "https://w3id.org/linkml/map/example/personinfo.yaml"
+    assert trs.target_schema.name == "https://w3id.org/linkml/map/example/agent.yaml"
 
     # class derivations
     class_derivs = {
@@ -303,8 +304,8 @@ def test_metadata_and_agent_roundtrip() -> None:
         mapping_method="semapv:ManualMappingCuration",
         documentation="https://example.org/docs",
         content_url="https://example.org/content.yaml",
-        source_schema="source.yaml",
-        target_schema="target.yaml",
+        source_schema=SchemaReference(name="source.yaml"),
+        target_schema=SchemaReference(name="target.yaml"),
         creator=[
             Person(id="orcid:0000-0001-1234-5678", name="Alice", orcid="orcid:0000-0001-1234-5678"),
             Organization(id="ror:03yrm5c26", name="Example Org", ror_id="ror:03yrm5c26"),
@@ -369,3 +370,48 @@ def test_create_transformer_specification_dict_input() -> None:
     assert len(spec.class_derivations) == 1
     assert spec.class_derivations[0].name == "Agent"
     assert spec.class_derivations[0].populated_from == "Person"
+
+
+def test_schema_reference_full_object() -> None:
+    """A dict input with all fields constructs a SchemaReference."""
+    spec = TransformationSpecification(
+        id="t",
+        source_schema={
+            "name": "personinfo",
+            "version": "1.2.3",
+            "schema_uri": "https://w3id.org/linkml/map/example/personinfo.yaml",
+            "source_file": "schemas/personinfo.yaml",
+        },
+    )
+    ref = spec.source_schema
+    assert isinstance(ref, SchemaReference)
+    assert ref.name == "personinfo"
+    assert ref.version == "1.2.3"
+    assert ref.schema_uri == "https://w3id.org/linkml/map/example/personinfo.yaml"
+    assert ref.source_file == "schemas/personinfo.yaml"
+
+
+def test_schema_reference_yaml_object_form_loads(tmp_path) -> None:
+    """A YAML spec using the structured object form loads with all fields."""
+    yaml_str = """\
+id: structured-spec
+source_schema:
+  name: personinfo
+  version: 1.0
+  schema_uri: https://w3id.org/linkml/map/example/personinfo.yaml
+  source_file: schemas/personinfo.yaml
+target_schema:
+  name: agent
+  version: 2.0
+"""
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(yaml_str)
+    tr = ObjectTransformer()
+    tr.load_transformer_specification(str(spec_path))
+    src = tr.specification.source_schema
+    assert src.name == "personinfo"
+    assert src.version == "1.0"
+    assert src.schema_uri == "https://w3id.org/linkml/map/example/personinfo.yaml"
+    assert src.source_file == "schemas/personinfo.yaml"
+    assert tr.specification.target_schema.name == "agent"
+    assert tr.specification.target_schema.version == "2.0"

--- a/tests/test_transformer/test_class_name_spaces.py
+++ b/tests/test_transformer/test_class_name_spaces.py
@@ -56,8 +56,8 @@ INPUT_OBJ = {
 
 def _make_transformer(transform_spec: dict) -> ObjectTransformer:
     """Build an ObjectTransformer from inline schemas and a transform dict."""
-    transform_spec["source_schema"] = "https://example.org/source"
-    transform_spec["target_schema"] = "https://example.org/target"
+    transform_spec["source_schema"] = {"name": "https://example.org/source"}
+    transform_spec["target_schema"] = {"name": "https://example.org/target"}
     tr = ObjectTransformer()
     tr.source_schemaview = SchemaView(SOURCE_SCHEMA)
     tr.target_schemaview = SchemaView(TARGET_SCHEMA)

--- a/tests/test_transformer/test_no_range_scalar.py
+++ b/tests/test_transformer/test_no_range_scalar.py
@@ -52,8 +52,8 @@ TARGET_SCHEMA = textwrap.dedent("""\
 def _make_transformer() -> ObjectTransformer:
     """Build a transformer with schemas that have slots without explicit ranges."""
     transform = {
-        "source_schema": "https://example.org/source",
-        "target_schema": "https://example.org/target",
+        "source_schema": {"name": "https://example.org/source"},
+        "target_schema": {"name": "https://example.org/target"},
         "class_derivations": {
             "Output": {
                 "populated_from": "Record",


### PR DESCRIPTION
Closes #161.

## Summary

`TransformationSpecification.source_schema` and `target_schema` are
promoted from plain strings to a new structured class `SchemaReference`
with the following attributes:

| field         | type     | required | purpose                                          |
| ------------- | -------- | -------- | ------------------------------------------------ |
| `name`        | string   | yes      | name/identifier of the schema                    |
| `version`     | string   | no       | version (semver, date-based, etc.)               |
| `schema_uri`  | uri      | no       | URI/IRI identifier (matches the schema's `id`)   |
| `source_file` | string   | no       | optional file path or URL for loading the schema |

This gives downstream tooling a place to record schema version, URI,
and locator metadata — closing the gap that #138 surfaced and unblocking
follow-on work on auto-loading.

## Breaking change — no backwards compatibility

Per the maintainer's call (see #161 comments: estimated impact "≤ 2"),
this PR does **not** ship a string→object coercion shim. Existing specs
must migrate:

```yaml
# before
source_schema: my_source.yaml
target_schema: my_target.yaml

# after
source_schema:
  name: my_source.yaml
target_schema:
  name: my_target.yaml
```

All in-tree YAML examples (`tests/input/examples/**`,
`tests/scaffold/**`, `tests/input/examples/fair_mappings_metadata/**`)
have been migrated.

## Changes

- **Schema (`src/linkml_map/datamodel/transformer_model.yaml`)**
  - New `SchemaReference` class.
  - `source_schema` and `target_schema` retyped to
    `range: SchemaReference, inlined: true`.
- **Generated Pydantic model
  (`src/linkml_map/datamodel/transformer_model.py`)** — regenerated via
  the existing Makefile rule (`make src/linkml_map/datamodel/transformer_model.py`).
  No hand-edits.
- **Tests**
  - `tests/test_datamodel.py` updated to access `.name` on the
    `SchemaReference` and to construct via the object form. Added two
    new tests covering full-object construction and YAML loading.
  - `tests/test_transformer/test_no_range_scalar.py` and
    `tests/test_transformer/test_class_name_spaces.py` migrated to the
    dict form.
- **YAML examples** in `tests/input/examples` and `tests/scaffold`
  migrated.

## Test plan

- [x] `uv run pytest -q` — 686 passed, 4 skipped (the single failing
      `test_graphviz_compiler.py::test_compile` is a pre-existing
      environment issue: `dot` not on PATH).
- [x] `uv run pytest --doctest-modules src/linkml_map -q` — 17 passed.
- [x] `make src/linkml_map/datamodel/transformer_model.py` regenerates
      cleanly from YAML; output matches the committed file.
