### PR TITLE
tests: drop CliRunner mix_stderr kwarg

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -34,7 +34,7 @@ def runner() -> CliRunner:
     :return: command line interface runner
     :rtype: CliRunner
     """
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def test_main_help(runner: CliRunner) -> None:

--- a/tests/test_cli/test_cli_multi_spec.py
+++ b/tests/test_cli/test_cli_multi_spec.py
@@ -15,7 +15,7 @@ TABULAR_TRANSFORM = TABULAR_TEST_DIR / "transform" / "person_to_agent.transform.
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -19,7 +19,7 @@ TABULAR_TRANSFORM = TABULAR_TEST_DIR / "transform" / "person_to_agent.transform.
 @pytest.fixture
 def runner() -> CliRunner:
     """Command line interface test runner."""
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture

--- a/tests/test_cli/test_cli_validate.py
+++ b/tests/test_cli/test_cli_validate.py
@@ -15,7 +15,7 @@ from tests import (
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def test_validate_spec_valid_file(runner: CliRunner) -> None:


### PR DESCRIPTION
Fixes #218.

click 8.3 removed `CliRunner(..., mix_stderr=...)`. The CLI tests don't assert on stderr separately, so the default runner behavior is fine here.

(Heads up: I couldn't run the test suite locally because this machine is on Python 3.14 and `pyproject.toml` caps Python at <3.14.)