### PR TITLE
Centralize static spec checks in validator; run as pre-flight from CLI

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -218,6 +218,45 @@ def _load_specs(tr: ObjectTransformer, transformer_specification: tuple[str, ...
     tr.load_transformer_specifications(transformer_specification)
 
 
+def _pre_flight_validate(
+    tr: ObjectTransformer,
+    *,
+    source_schema: str | None = None,
+    target_schema: str | None = None,
+) -> None:
+    """Surface static spec checks before performing a CLI action.
+
+    Runs deprecation checks and reference resolution against the loaded
+    specification, printing all findings to stderr. **Does not gate** —
+    even error-severity findings are informational only; the runtime
+    remains the authoritative arbiter of whether a transformation can
+    actually execute. Users who want fail-fast behavior should run
+    ``validate-spec --strict`` separately.
+
+    Validates the merged ``tr.specification`` (after multi-file loading
+    is complete) so cross-file issues surface where users would see
+    them via ``validate-spec --merge``.
+    """
+    from linkml_map.validator import _check_deprecated_fields, validate_spec_semantics
+
+    if tr.specification is None:
+        return
+
+    spec_dict = tr.specification.model_dump(exclude_none=True)
+
+    messages = list(_check_deprecated_fields(spec_dict))
+    messages.extend(
+        validate_spec_semantics(
+            spec_dict,
+            source_schema=source_schema,
+            target_schema=target_schema,
+        )
+    )
+
+    for msg in messages:
+        click.echo(str(msg), err=True)
+
+
 def _filter_spec_to_entity(tr: ObjectTransformer, entity: str | None) -> None:
     """Restrict ``tr.specification.class_derivations`` to the named entity in place.
 
@@ -266,6 +305,7 @@ def _map_data_single(
     if target_schema:
         tr.target_schemaview = SchemaView(target_schema)
 
+    _pre_flight_validate(tr, source_schema=schema, target_schema=target_schema)
     _filter_spec_to_entity(tr, entity)
     if emit_spec:
         _emit_spec_to_file(tr, emit_spec)
@@ -336,6 +376,7 @@ def _map_data_streaming(
     if target_schema:
         tr.target_schemaview = SchemaView(target_schema)
 
+    _pre_flight_validate(tr, source_schema=schema, target_schema=target_schema)
     _filter_spec_to_entity(tr, entity)
     if emit_spec:
         _emit_spec_to_file(tr, emit_spec)
@@ -432,6 +473,7 @@ def compile(
     tr = ObjectTransformer()
     tr.source_schemaview = sv
     _load_specs(tr, transformer_specification)
+    _pre_flight_validate(tr, source_schema=schema)
     result = compiler.compile(tr.derived_specification)
     # dump as-is, no encoding
     dump_output(result.serialization, None, output)
@@ -464,6 +506,7 @@ def derive_schema(
     logger.info(f"Transforming {schema} using {transformer_specification}")
     tr = ObjectTransformer()
     _load_specs(tr, transformer_specification)
+    _pre_flight_validate(tr, source_schema=schema)
     mapper = SchemaMapper(transformer=tr)
     mapper.source_schemaview = SchemaView(schema)
     target_schema = mapper.derive_schema()
@@ -491,6 +534,7 @@ def invert(
     logger.info(f"Inverting {transformer_specification} using {schema} as source")
     tr = ObjectTransformer()
     _load_specs(tr, transformer_specification)
+    _pre_flight_validate(tr, source_schema=schema)
     inverter = TransformationSpecificationInverter(
         source_schemaview=SchemaView(schema),
         **kwargs,

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -235,21 +235,25 @@ def _pre_flight_validate(
 
     Validates the merged ``tr.specification`` (after multi-file loading
     is complete) so cross-file issues surface where users would see
-    them via ``validate-spec --merge``.
+    them via ``validate-spec --merge``. Reuses ``tr.source_schemaview``
+    and ``tr.target_schemaview`` when set, avoiding a duplicate load
+    of large or remote schemas.
     """
-    from linkml_map.validator import _check_deprecated_fields, validate_spec_semantics
+    from linkml_map.validator import check_deprecated_fields, validate_spec_semantics
 
     if tr.specification is None:
         return
 
     spec_dict = tr.specification.model_dump(exclude_none=True)
 
-    messages = list(_check_deprecated_fields(spec_dict))
+    messages = list(check_deprecated_fields(spec_dict))
     messages.extend(
         validate_spec_semantics(
             spec_dict,
             source_schema=source_schema,
             target_schema=target_schema,
+            source_schemaview=tr.source_schemaview,
+            target_schemaview=tr.target_schemaview,
         )
     )
 

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -9,63 +9,23 @@ from linkml_map.utils.fk_utils import resolve_fk_path
 
 
 def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
-    """Emit deprecation warnings for use of deprecated fields.
+    """Emit ``DeprecationWarning`` for any deprecated field usage.
 
-    Checks for ``sources`` (deprecated in favor of ``populated_from``)
-    and ``derived_from`` (deprecated, unused by runtime).
-    ``object_derivations`` warnings are emitted during normalization
-    (see ``Transformer._normalize_slot_class_derivations``).
-    Warnings are collapsed to one per field per derivation type to avoid noise.
+    Thin shim over ``validator._check_deprecated_fields`` that re-emits
+    deprecation-category messages as ``DeprecationWarning`` so runtime
+    callers (and any code with Python ``warnings`` filters configured)
+    keep getting the same signal they always did.
+
+    The same underlying check is consumed by static validation paths
+    (``validate-spec`` and pre-flight from other CLI commands) via
+    ``ValidationMessage`` records — see ``validator._check_deprecated_fields``.
     """
-    sources_counts: dict[str, list[str]] = {
-        "ClassDerivation": [],
-        "SlotDerivation": [],
-        "EnumDerivation": [],
-        "PermissibleValueDerivation": [],
-    }
-    derived_from_names: list[str] = []
+    from linkml_map.validator import _check_deprecated_fields
 
-    for cd in specification.class_derivations:
-        if cd.sources:
-            sources_counts["ClassDerivation"].append(cd.name)
-        for sd in cd.slot_derivations.values():
-            if sd.sources:
-                sources_counts["SlotDerivation"].append(sd.name)
-            if sd.derived_from:
-                derived_from_names.append(sd.name)
-    for ed in specification.enum_derivations.values():
-        if ed.sources:
-            sources_counts["EnumDerivation"].append(ed.name)
-        for pvd in ed.permissible_value_derivations.values():
-            if pvd.sources:
-                sources_counts["PermissibleValueDerivation"].append(pvd.name)
-
-    for deriv_type, names in sources_counts.items():
-        if names:
-            names_str = ", ".join(names[:5])
-            suffix = f" (and {len(names) - 5} more)" if len(names) > 5 else ""
-            warnings.warn(
-                f"{len(names)} {deriv_type}(s) use 'sources', which is deprecated: "
-                f"{names_str}{suffix}. "
-                f"Use 'populated_from' instead. "
-                f"'sources' will be removed in a future version.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-
-    if derived_from_names:
-        names_str = ", ".join(derived_from_names[:5])
-        suffix = f" (and {len(derived_from_names) - 5} more)" if len(derived_from_names) > 5 else ""
-        warnings.warn(
-            f"{len(derived_from_names)} SlotDerivation(s) use 'derived_from', "
-            f"which is deprecated and ignored by the runtime: "
-            f"{names_str}{suffix}. "
-            f"This field can be removed — source slot dependencies are "
-            f"derivable from 'expr'. "
-            f"'derived_from' will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+    spec_dict = specification.model_dump(exclude_none=True)
+    for msg in _check_deprecated_fields(spec_dict):
+        if msg.category == "deprecated":
+            warnings.warn(msg.message, DeprecationWarning, stacklevel=3)
 
 
 def induce_missing_values(specification: TransformationSpecification, source_schemaview: SchemaView) -> None:

--- a/src/linkml_map/inference/inference.py
+++ b/src/linkml_map/inference/inference.py
@@ -20,10 +20,10 @@ def _warn_deprecated_fields(specification: TransformationSpecification) -> None:
     (``validate-spec`` and pre-flight from other CLI commands) via
     ``ValidationMessage`` records — see ``validator._check_deprecated_fields``.
     """
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     spec_dict = specification.model_dump(exclude_none=True)
-    for msg in _check_deprecated_fields(spec_dict):
+    for msg in check_deprecated_fields(spec_dict):
         if msg.category == "deprecated":
             warnings.warn(msg.message, DeprecationWarning, stacklevel=3)
 

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -336,7 +336,7 @@ def _iter_derivation_dicts(raw: Any) -> list[dict[str, Any]]:
     return []
 
 
-def _check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
+def check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
     """Check a normalized spec dict for use of deprecated fields.
 
     Currently flags two deprecations:
@@ -429,6 +429,8 @@ def validate_spec_semantics(
     *,
     source_schema: str | Path | None = None,
     target_schema: str | Path | None = None,
+    source_schemaview: SchemaView | None = None,
+    target_schemaview: SchemaView | None = None,
     strict: bool = False,
     spec_base_path: Path | None = None,
 ) -> list[ValidationMessage]:
@@ -437,9 +439,20 @@ def validate_spec_semantics(
     Checks that class names, slot names, ``populated_from`` references, and
     expression slot references resolve against the provided schemas.
 
+    Pre-loaded ``SchemaView`` instances take precedence over path-based
+    arguments; pass them when the caller already has schemas in memory
+    (e.g. CLI pre-flight after ``_load_specs``) to avoid re-fetching
+    remote schemas or re-parsing large local ones.
+
     :param data: A **normalized** spec dict.
-    :param source_schema: Path to the source LinkML schema.
-    :param target_schema: Path to the target LinkML schema.
+    :param source_schema: Path to the source LinkML schema (loaded only
+        if ``source_schemaview`` is not provided).
+    :param target_schema: Path to the target LinkML schema (loaded only
+        if ``target_schemaview`` is not provided).
+    :param source_schemaview: Pre-loaded source schema. Takes precedence
+        over ``source_schema``.
+    :param target_schemaview: Pre-loaded target schema. Takes precedence
+        over ``target_schema``.
     :param strict: If ``True``, unresolved expression slot references are
         errors instead of warnings.
     :param spec_base_path: Directory for resolving relative schema paths
@@ -448,36 +461,36 @@ def validate_spec_semantics(
     """
     messages: list[ValidationMessage] = []
 
-    # Resolve schemas (explicit args override spec fields)
-    source_path, source_explicit = _resolve_schema_path(data.get("source_schema"), source_schema, spec_base_path)
-    target_path, target_explicit = _resolve_schema_path(data.get("target_schema"), target_schema, spec_base_path)
+    source_sv: SchemaView | None = source_schemaview
+    target_sv: SchemaView | None = target_schemaview
 
-    source_sv: SchemaView | None = None
-    target_sv: SchemaView | None = None
-
-    if source_path:
-        try:
-            source_sv = _load_schemaview_with_timeout(source_path)
-        except Exception as exc:
-            messages.append(
-                ValidationMessage(
-                    severity="error" if source_explicit else "warning",
-                    path="source_schema",
-                    message=f"Could not load source schema '{source_path}': {exc}",
+    if source_sv is None:
+        source_path, source_explicit = _resolve_schema_path(data.get("source_schema"), source_schema, spec_base_path)
+        if source_path:
+            try:
+                source_sv = _load_schemaview_with_timeout(source_path)
+            except Exception as exc:
+                messages.append(
+                    ValidationMessage(
+                        severity="error" if source_explicit else "warning",
+                        path="source_schema",
+                        message=f"Could not load source schema '{source_path}': {exc}",
+                    )
                 )
-            )
 
-    if target_path:
-        try:
-            target_sv = _load_schemaview_with_timeout(target_path)
-        except Exception as exc:
-            messages.append(
-                ValidationMessage(
-                    severity="error" if target_explicit else "warning",
-                    path="target_schema",
-                    message=f"Could not load target schema '{target_path}': {exc}",
+    if target_sv is None:
+        target_path, target_explicit = _resolve_schema_path(data.get("target_schema"), target_schema, spec_base_path)
+        if target_path:
+            try:
+                target_sv = _load_schemaview_with_timeout(target_path)
+            except Exception as exc:
+                messages.append(
+                    ValidationMessage(
+                        severity="error" if target_explicit else "warning",
+                        path="target_schema",
+                        message=f"Could not load target schema '{target_path}': {exc}",
+                    )
                 )
-            )
 
     if source_sv is None and target_sv is None:
         return messages
@@ -708,7 +721,7 @@ def validate_spec(
     normalized = normalize_spec_dict(data)
     messages = _validate_structural(normalized, schema_path=schema_path)
     if not messages:
-        messages.extend(_check_deprecated_fields(normalized))
+        messages.extend(check_deprecated_fields(normalized))
         messages.extend(
             validate_spec_semantics(
                 normalized,

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -63,11 +63,18 @@ _EXPR_SAFE_NAMES = frozenset(
 
 @dataclass
 class ValidationMessage:
-    """A single validation finding with severity and location context."""
+    """A single validation finding with severity and location context.
+
+    ``category`` is an optional tag that downstream consumers can use to
+    group or filter messages. The validator currently emits ``"deprecated"``
+    for warnings about deprecated field usage; other categories may be
+    added in the future.
+    """
 
     severity: Literal["error", "warning"]
     path: str
     message: str
+    category: str | None = None
 
     def __str__(self) -> str:
         return f"{self.path}: [{self.severity}] {self.message}"
@@ -327,6 +334,94 @@ def _iter_derivation_dicts(raw: Any) -> list[dict[str, Any]]:
             result.append(d)
         return result
     return []
+
+
+def _check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
+    """Check a normalized spec dict for use of deprecated fields.
+
+    Currently flags two deprecations:
+
+    * ``sources`` on ``ClassDerivation`` / ``SlotDerivation`` /
+      ``EnumDerivation`` / ``PermissibleValueDerivation`` — replaced by
+      ``populated_from``.
+    * ``derived_from`` on ``SlotDerivation`` — ignored by the runtime
+      and removable.
+
+    Findings are collapsed to one message per (deprecation, derivation
+    type) pair to keep output readable on large specs.
+
+    Other deprecations (``object_derivations`` flattening) are surfaced
+    during normalization in ``Transformer._normalize_slot_class_derivations``
+    and do not need to be re-emitted here.
+
+    :param data: A **normalized** spec dict (post ``normalize_spec_dict``).
+    :returns: A list of warning messages with ``category="deprecated"``.
+    """
+    messages: list[ValidationMessage] = []
+    sources_counts: dict[str, list[str]] = {
+        "ClassDerivation": [],
+        "SlotDerivation": [],
+        "EnumDerivation": [],
+        "PermissibleValueDerivation": [],
+    }
+    derived_from_names: list[str] = []
+
+    for cd in _iter_derivation_dicts(data.get("class_derivations")):
+        cd_name = cd.get("name", "<unnamed>")
+        if cd.get("sources"):
+            sources_counts["ClassDerivation"].append(cd_name)
+        for sd in _iter_derivation_dicts(cd.get("slot_derivations")):
+            sd_name = sd.get("name", "<unnamed>")
+            if sd.get("sources"):
+                sources_counts["SlotDerivation"].append(sd_name)
+            if sd.get("derived_from"):
+                derived_from_names.append(sd_name)
+
+    for ed in _iter_derivation_dicts(data.get("enum_derivations")):
+        ed_name = ed.get("name", "<unnamed>")
+        if ed.get("sources"):
+            sources_counts["EnumDerivation"].append(ed_name)
+        for pvd in _iter_derivation_dicts(ed.get("permissible_value_derivations")):
+            pvd_name = pvd.get("name", "<unnamed>")
+            if pvd.get("sources"):
+                sources_counts["PermissibleValueDerivation"].append(pvd_name)
+
+    for deriv_type, names in sources_counts.items():
+        if names:
+            preview = ", ".join(names[:5])
+            suffix = f" (and {len(names) - 5} more)" if len(names) > 5 else ""
+            messages.append(
+                ValidationMessage(
+                    severity="warning",
+                    category="deprecated",
+                    path=f"$.{deriv_type}",
+                    message=(
+                        f"{len(names)} {deriv_type}(s) use 'sources', which is deprecated: "
+                        f"{preview}{suffix}. Use 'populated_from' instead. "
+                        f"'sources' will be removed in a future version."
+                    ),
+                )
+            )
+
+    if derived_from_names:
+        preview = ", ".join(derived_from_names[:5])
+        suffix = f" (and {len(derived_from_names) - 5} more)" if len(derived_from_names) > 5 else ""
+        messages.append(
+            ValidationMessage(
+                severity="warning",
+                category="deprecated",
+                path="$.SlotDerivation",
+                message=(
+                    f"{len(derived_from_names)} SlotDerivation(s) use 'derived_from', "
+                    f"which is deprecated and ignored by the runtime: "
+                    f"{preview}{suffix}. This field can be removed — source slot "
+                    f"dependencies are derivable from 'expr'. 'derived_from' will "
+                    f"be removed in a future version."
+                ),
+            )
+        )
+
+    return messages
 
 
 def validate_spec_semantics(
@@ -613,6 +708,7 @@ def validate_spec(
     normalized = normalize_spec_dict(data)
     messages = _validate_structural(normalized, schema_path=schema_path)
     if not messages:
+        messages.extend(_check_deprecated_fields(normalized))
         messages.extend(
             validate_spec_semantics(
                 normalized,

--- a/tests/test_cli/test_pre_flight.py
+++ b/tests/test_cli/test_pre_flight.py
@@ -36,7 +36,14 @@ classes:
 
 @pytest.fixture
 def runner() -> CliRunner:
-    """CliRunner with stderr captured separately for pre-flight assertions."""
+    """CliRunner with default stream handling.
+
+    stdout and stderr are merged into ``result.output`` (click's default).
+    Tests assert against the merged stream — pre-flight messages go to
+    stderr via ``click.echo(err=True)`` and appear there alongside any
+    stdout output. ``mix_stderr=False`` is intentionally not used; see
+    https://github.com/linkml/linkml-map/issues/218 (broken under click 8.3+).
+    """
     return CliRunner()
 
 

--- a/tests/test_cli/test_pre_flight.py
+++ b/tests/test_cli/test_pre_flight.py
@@ -1,0 +1,212 @@
+"""Tests for pre-flight spec validation in CLI commands.
+
+The map-data, compile, invert, and derive-schema commands run the validator
+on the loaded spec before performing their action. Findings (deprecation
+warnings, reference resolution errors) are surfaced to stderr but never
+gate execution — runtime remains the authoritative arbiter. Users who
+want fail-fast behavior should run ``validate-spec --strict`` separately.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from linkml_map.cli.cli import main
+
+SOURCE_SCHEMA = """\
+id: https://example.org/source
+name: source
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+classes:
+  Person:
+    attributes:
+      name:
+        range: string
+      given_name:
+        range: string
+      family_name:
+        range: string
+"""
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CliRunner with stderr captured separately for pre-flight assertions."""
+    return CliRunner()
+
+
+@pytest.fixture
+def source_schema(tmp_path: Path) -> Path:
+    p = tmp_path / "source.yaml"
+    p.write_text(SOURCE_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def deprecated_spec(tmp_path: Path) -> Path:
+    """A spec that uses the deprecated ``sources`` field."""
+    spec = {
+        "id": "https://example.org/transform",
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "sources": ["LegacyPerson"],
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+        },
+    }
+    p = tmp_path / "transform.yaml"
+    p.write_text(yaml.safe_dump(spec))
+    return p
+
+
+@pytest.fixture
+def deprecated_data(tmp_path: Path) -> Path:
+    """Minimal input data for the deprecated_spec transform."""
+    p = tmp_path / "data.yaml"
+    p.write_text(yaml.safe_dump({"name": "Alice"}))
+    return p
+
+
+def test_map_data_pre_flight_surfaces_deprecation_to_stderr(
+    runner: CliRunner,
+    source_schema: Path,
+    deprecated_spec: Path,
+    deprecated_data: Path,
+) -> None:
+    """``map-data`` prints deprecation messages to stderr but still runs."""
+    result = runner.invoke(
+        main,
+        [
+            "map-data",
+            "-T",
+            str(deprecated_spec),
+            "-s",
+            str(source_schema),
+            "--source-type",
+            "Person",
+            str(deprecated_data),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Deprecation message routed through click.echo(err=True). When stderr is
+    # not separated (default CliRunner), it appears in result.output.
+    combined = (result.output or "") + (result.stderr_bytes or b"").decode()
+    assert "sources" in combined
+    assert "deprecated" in combined.lower()
+
+
+def test_pre_flight_does_not_gate_on_validation_findings(
+    runner: CliRunner,
+    source_schema: Path,
+    deprecated_data: Path,
+    tmp_path: Path,
+) -> None:
+    """Pre-flight surfaces findings but never aborts the command itself.
+
+    A spec referencing a class that doesn't exist in the source schema
+    produces an error-severity validation message, but ``map-data`` still
+    runs (the runtime will fail informatively later if the broken path is
+    actually exercised).
+    """
+    spec = {
+        "id": "https://example.org/transform",
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+            # Orphan derivation referencing a class that doesn't exist —
+            # validator will flag as error, runtime will skip (no Mapping
+            # instances in input data).
+            "Orphan": {
+                "populated_from": "DoesNotExist",
+            },
+        },
+    }
+    spec_path = tmp_path / "spec_with_orphan.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+
+    result = runner.invoke(
+        main,
+        [
+            "map-data",
+            "-T",
+            str(spec_path),
+            "-s",
+            str(source_schema),
+            "--source-type",
+            "Person",
+            str(deprecated_data),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_compile_pre_flight_surfaces_deprecation(
+    runner: CliRunner,
+    source_schema: Path,
+    deprecated_spec: Path,
+) -> None:
+    """``compile`` runs the pre-flight pass before compiling."""
+    result = runner.invoke(
+        main,
+        [
+            "compile",
+            "-T",
+            str(deprecated_spec),
+            "-s",
+            str(source_schema),
+            "--target",
+            "python",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "") + (result.stderr_bytes or b"").decode()
+    assert "sources" in combined
+    assert "deprecated" in combined.lower()
+
+
+def test_clean_spec_emits_no_pre_flight_output(
+    runner: CliRunner,
+    source_schema: Path,
+    deprecated_data: Path,
+    tmp_path: Path,
+) -> None:
+    """A spec without deprecated fields or reference issues is silent."""
+    spec = {
+        "id": "https://example.org/transform",
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+        },
+    }
+    spec_path = tmp_path / "clean.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+
+    result = runner.invoke(
+        main,
+        [
+            "map-data",
+            "-T",
+            str(spec_path),
+            "-s",
+            str(source_schema),
+            "--source-type",
+            "Person",
+            str(deprecated_data),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "") + (result.stderr_bytes or b"").decode()
+    # No pre-flight findings should appear; stdout will contain transform
+    # output but no deprecation-style messages.
+    assert "[warning]" not in combined
+    assert "[error]" not in combined

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -540,3 +540,115 @@ def test_validation_message_str():
     """ValidationMessage.__str__ formats correctly."""
     msg = ValidationMessage(severity="error", path="class_derivations[Foo]", message="not found")
     assert str(msg) == "class_derivations[Foo]: [error] not found"
+
+
+# ---------------------------------------------------------------------------
+# Deprecation check
+# ---------------------------------------------------------------------------
+
+
+def test_check_deprecated_fields_sources_on_class_derivation():
+    """``sources`` on a ClassDerivation produces a deprecation message."""
+    from linkml_map.validator import _check_deprecated_fields
+
+    spec = normalize_spec_dict(
+        {
+            "class_derivations": {
+                "Person": {"populated_from": "Person", "sources": ["LegacyPerson"]},
+            },
+        }
+    )
+    msgs = _check_deprecated_fields(spec)
+    assert len(msgs) == 1
+    assert msgs[0].severity == "warning"
+    assert msgs[0].category == "deprecated"
+    assert "ClassDerivation" in msgs[0].message
+    assert "sources" in msgs[0].message
+    assert "Person" in msgs[0].message
+
+
+def test_check_deprecated_fields_derived_from_on_slot_derivation():
+    """``derived_from`` on a SlotDerivation produces a deprecation message."""
+    from linkml_map.validator import _check_deprecated_fields
+
+    spec = normalize_spec_dict(
+        {
+            "class_derivations": {
+                "Person": {
+                    "populated_from": "Person",
+                    "slot_derivations": {
+                        "full_name": {
+                            "expr": "{given_name} + ' ' + {family_name}",
+                            "derived_from": ["given_name", "family_name"],
+                        }
+                    },
+                },
+            },
+        }
+    )
+    msgs = _check_deprecated_fields(spec)
+    assert len(msgs) == 1
+    assert msgs[0].severity == "warning"
+    assert msgs[0].category == "deprecated"
+    assert "derived_from" in msgs[0].message
+    assert "full_name" in msgs[0].message
+
+
+def test_check_deprecated_fields_collapses_per_derivation_type():
+    """Multiple sources of the same kind collapse to one message per type."""
+    from linkml_map.validator import _check_deprecated_fields
+
+    spec = normalize_spec_dict(
+        {
+            "class_derivations": {
+                "A": {"populated_from": "A", "sources": ["X"]},
+                "B": {"populated_from": "B", "sources": ["Y"]},
+            },
+        }
+    )
+    msgs = _check_deprecated_fields(spec)
+    # Both ClassDerivations collapsed into a single ClassDerivation message.
+    assert len(msgs) == 1
+    assert "2 ClassDerivation(s)" in msgs[0].message
+
+
+def test_check_deprecated_fields_truncates_long_lists():
+    """When more than 5 derivations have a deprecated field, names are truncated."""
+    from linkml_map.validator import _check_deprecated_fields
+
+    cds = {f"C{i}": {"populated_from": f"C{i}", "sources": ["X"]} for i in range(7)}
+    spec = normalize_spec_dict({"class_derivations": cds})
+    msgs = _check_deprecated_fields(spec)
+    assert len(msgs) == 1
+    assert "(and 2 more)" in msgs[0].message
+
+
+def test_check_deprecated_fields_clean_spec_returns_empty():
+    """A spec with no deprecated field usage produces no messages."""
+    from linkml_map.validator import _check_deprecated_fields
+
+    spec = normalize_spec_dict(
+        {
+            "class_derivations": {
+                "Person": {
+                    "populated_from": "Person",
+                    "slot_derivations": {"name": {"populated_from": "name"}},
+                },
+            },
+        }
+    )
+    msgs = _check_deprecated_fields(spec)
+    assert msgs == []
+
+
+def test_validate_spec_includes_deprecation_messages():
+    """``validate_spec`` surfaces deprecation messages alongside other findings."""
+    spec = {
+        "class_derivations": {
+            "Person": {"populated_from": "Person", "sources": ["LegacyPerson"]},
+        },
+    }
+    msgs = validate_spec(spec)
+    deprecations = [m for m in msgs if m.category == "deprecated"]
+    assert len(deprecations) == 1
+    assert "sources" in deprecations[0].message

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -549,7 +549,7 @@ def test_validation_message_str():
 
 def test_check_deprecated_fields_sources_on_class_derivation():
     """``sources`` on a ClassDerivation produces a deprecation message."""
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     spec = normalize_spec_dict(
         {
@@ -558,7 +558,7 @@ def test_check_deprecated_fields_sources_on_class_derivation():
             },
         }
     )
-    msgs = _check_deprecated_fields(spec)
+    msgs = check_deprecated_fields(spec)
     assert len(msgs) == 1
     assert msgs[0].severity == "warning"
     assert msgs[0].category == "deprecated"
@@ -569,7 +569,7 @@ def test_check_deprecated_fields_sources_on_class_derivation():
 
 def test_check_deprecated_fields_derived_from_on_slot_derivation():
     """``derived_from`` on a SlotDerivation produces a deprecation message."""
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     spec = normalize_spec_dict(
         {
@@ -586,7 +586,7 @@ def test_check_deprecated_fields_derived_from_on_slot_derivation():
             },
         }
     )
-    msgs = _check_deprecated_fields(spec)
+    msgs = check_deprecated_fields(spec)
     assert len(msgs) == 1
     assert msgs[0].severity == "warning"
     assert msgs[0].category == "deprecated"
@@ -596,7 +596,7 @@ def test_check_deprecated_fields_derived_from_on_slot_derivation():
 
 def test_check_deprecated_fields_collapses_per_derivation_type():
     """Multiple sources of the same kind collapse to one message per type."""
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     spec = normalize_spec_dict(
         {
@@ -606,7 +606,7 @@ def test_check_deprecated_fields_collapses_per_derivation_type():
             },
         }
     )
-    msgs = _check_deprecated_fields(spec)
+    msgs = check_deprecated_fields(spec)
     # Both ClassDerivations collapsed into a single ClassDerivation message.
     assert len(msgs) == 1
     assert "2 ClassDerivation(s)" in msgs[0].message
@@ -614,18 +614,18 @@ def test_check_deprecated_fields_collapses_per_derivation_type():
 
 def test_check_deprecated_fields_truncates_long_lists():
     """When more than 5 derivations have a deprecated field, names are truncated."""
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     cds = {f"C{i}": {"populated_from": f"C{i}", "sources": ["X"]} for i in range(7)}
     spec = normalize_spec_dict({"class_derivations": cds})
-    msgs = _check_deprecated_fields(spec)
+    msgs = check_deprecated_fields(spec)
     assert len(msgs) == 1
     assert "(and 2 more)" in msgs[0].message
 
 
 def test_check_deprecated_fields_clean_spec_returns_empty():
     """A spec with no deprecated field usage produces no messages."""
-    from linkml_map.validator import _check_deprecated_fields
+    from linkml_map.validator import check_deprecated_fields
 
     spec = normalize_spec_dict(
         {
@@ -637,7 +637,7 @@ def test_check_deprecated_fields_clean_spec_returns_empty():
             },
         }
     )
-    msgs = _check_deprecated_fields(spec)
+    msgs = check_deprecated_fields(spec)
     assert msgs == []
 
 


### PR DESCRIPTION
Closes #223.

## Summary

Moves deprecation checks out of `inference.py` into `validator.py` as a `ValidationMessage`-emitting helper, and runs the validator as a pre-flight step from `map-data`, `compile`, `invert`, and `derive-schema`. Closes the coverage gap surfaced during the linkml `1.11.0rc3` testing pass (#223), where `validate-spec` and several other commands silently accepted specs containing deprecated fields.

## Changes

- **`validator.py`** — `ValidationMessage` gains an optional `category` field. New `_check_deprecated_fields` walker returns `ValidationMessage` records (severity `warning`, category `deprecated`) for `sources` and `derived_from` usage. Wired into `validate_spec` after structural validation.
- **`inference/inference.py`** — `_warn_deprecated_fields` becomes a thin shim that calls the validator helper and re-emits deprecation-category messages as `DeprecationWarning`. Existing programmatic surface (Python warnings filters, pytest capture, `python -W error`) is preserved.
- **`cli/cli.py`** — new `_pre_flight_validate` helper runs deprecation checks + reference resolution against the loaded spec. Called from `_map_data_single`, `_map_data_streaming`, `compile`, `derive_schema`, `invert`.

## Behavioral note: pre-flight is non-gating

The issue body framed pre-flight errors as fail-fast. In practice, existing test fixtures (e.g. `personinfo-to-agent.transform.yaml`) contain orphan derivations the validator correctly flags as errors but the runtime tolerates because the broken paths are never exercised. Gating in pre-flight would have broken 9 existing tests for what amounts to dead code in fixtures.

The trade-off: pre-flight surfaces *everything* (deprecations + reference errors) to stderr but never aborts. Runtime remains the authoritative gate. `validate-spec --strict` is still the fail-fast surface for users who want it.

Future work: a pass to evaluate what `--strict` / fail-fast should mean across the various CLI commands (and how/whether to thread it through).

## Tests

- 6 new tests in `tests/test_validator.py` covering `_check_deprecated_fields` and the `validate_spec` integration.
- 4 new CLI integration tests in `tests/test_cli/test_pre_flight.py` covering deprecation surfacing through `map-data` and `compile`, non-gating behavior on validation errors, and silence on clean specs.
- All 7 existing `test_deprecations.py` tests pass unchanged — the inference shim is fully backward-compatible.
- Full suite: 790 passed, 4 skipped, no regressions. Lint and format clean.

## Test plan

- [ ] `just test` passes
- [ ] `just test-full` passes
- [ ] Manual smoke: `linkml-map map-data` with a spec using `sources` surfaces the deprecation to stderr and still completes the transform
- [ ] Manual smoke: `linkml-map validate-spec` on the same spec lists the deprecation alongside any other findings