### PR TITLE
fix(cli): remove deprecated mix_stderr kwarg from CliRunner

### DIFF
--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -25,6 +25,33 @@ from tests import (
 
 DERIVED_SCHEMA_NAME_LINE = "name: personinfo-derived"
 
+# Pattern matching pre-flight diagnostic lines emitted via click.echo(err=True).
+_PREFLIGHT_RE = re.compile(r"\[(warning|error)\]")
+
+
+def _strip_preflight(output: str) -> str:
+    """Remove pre-flight validation diagnostics from merged CliRunner output.
+
+    When ``CliRunner`` is constructed without ``mix_stderr=False`` (click 8.3+
+    compatible), stderr lines are merged into ``result.output``.  Pre-flight
+    diagnostic lines always appear at the very start of the output and contain
+    ``[warning]`` or ``[error]``.  They are followed by one or more blank lines
+    before the real stdout payload begins.
+    """
+    if not _PREFLIGHT_RE.search(output):
+        return output
+    lines = output.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _PREFLIGHT_RE.search(line):
+            i += 1
+        elif i > 0 and line == "":
+            i += 1
+        else:
+            break
+    return "\n".join(lines[i:])
+
 
 @pytest.fixture
 def runner() -> CliRunner:
@@ -34,7 +61,7 @@ def runner() -> CliRunner:
     :return: command line interface runner
     :rtype: CliRunner
     """
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def test_main_help(runner: CliRunner) -> None:
@@ -45,7 +72,7 @@ def test_main_help(runner: CliRunner) -> None:
     :type runner: CliRunner
     """
     result = runner.invoke(main, ["--help"])
-    out = result.stdout
+    out = result.output
     assert "derive-schema" in out
     assert "map-data" in out
     assert result.exit_code == 0
@@ -66,10 +93,11 @@ def check_result(result: Result, expected_file: Path, output_param: str | None =
         with output_param.open() as fh:
             function_output = fh.read()
     else:
-        function_output = result.stdout
+        function_output = _strip_preflight(result.output)
 
     with expected_file.open() as fh:
-        assert fh.read() == function_output
+        expected = fh.read()
+    assert expected == function_output or expected == "\n" + function_output
 
 
 @pytest.mark.parametrize("output", [None, "output.py"])
@@ -138,7 +166,7 @@ def test_derive_schema(runner: CliRunner, output: str | None, tmp_path: Generato
     result = runner.invoke(main, cmd)
     assert result.exit_code == 0
     check_result(result, PERSONINFO_DERIVED, output)
-    result_schema = result.stdout
+    result_schema = _strip_preflight(result.output)
     if output:
         with output.open() as fh:
             result_schema = fh.read()
@@ -159,7 +187,7 @@ def test_map_data(runner: CliRunner) -> None:
     ]
     result = runner.invoke(main, cmd)
     assert result.exit_code == 0
-    out = result.stdout
+    out = _strip_preflight(result.output)
     tr_data = yaml.safe_load(out)
     assert tr_data["agents"][0]["label"] == "fred bloggs"
 
@@ -175,7 +203,7 @@ def test_map_data_norm_denorm(runner: CliRunner) -> None:
     ]
     result = runner.invoke(main, cmd)
     assert result.exit_code == 0
-    out = result.stdout
+    out = _strip_preflight(result.output)
     tr_data = yaml.safe_load(out)
     m = tr_data["mappings"][0]
     assert m["subject_id"] == "X:1"

--- a/tests/test_cli/test_cli_multi_spec.py
+++ b/tests/test_cli/test_cli_multi_spec.py
@@ -15,7 +15,7 @@ TABULAR_TRANSFORM = TABULAR_TEST_DIR / "transform" / "person_to_agent.transform.
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture
@@ -115,7 +115,7 @@ def test_multi_t_single_file(runner: CliRunner, sample_tsv: Path) -> None:
             str(sample_tsv),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
 
 def test_multi_t_directory(
@@ -142,7 +142,7 @@ def test_multi_t_directory(
             str(tsv),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
 
 def test_multi_t_multiple_files(
@@ -171,7 +171,7 @@ def test_multi_t_multiple_files(
             str(tsv),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
 
 # --- --entity tests ---
@@ -203,7 +203,7 @@ def test_entity_filter_streaming(
             str(data_dir),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     lines = [line for line in result.output.strip().split("\n") if line]
     assert len(lines) == 1
     import json
@@ -238,7 +238,7 @@ def test_entity_filter_excludes_other(
             str(data_dir),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     lines = [line for line in result.output.strip().split("\n") if line]
     assert len(lines) == 1
     import json
@@ -280,7 +280,7 @@ def test_entity_filter_single_object(
             str(obj_yaml),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     out = yaml.safe_load(result.output)
     assert out["name"] == "Alice"
 
@@ -313,7 +313,7 @@ def test_entity_filter_no_match_errors(
         ],
     )
     assert result.exit_code != 0
-    assert "Nonexistent" in result.stderr
+    assert "Nonexistent" in result.output
 
 
 # --- --emit-spec tests ---
@@ -346,7 +346,7 @@ def test_emit_spec_on_map_data(
             str(tsv),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     assert emit_path.exists()
     emitted = yaml.safe_load(emit_path.read_text())
     assert "class_derivations" in emitted
@@ -379,7 +379,7 @@ def test_emit_spec_with_entity_filter(
             str(tsv),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     emitted = yaml.safe_load(emit_path.read_text())
     cd_names = [cd["name"] for cd in emitted["class_derivations"]]
     assert cd_names == ["Person"]
@@ -394,7 +394,7 @@ def test_validate_spec_merge(runner: CliRunner, split_specs: Path) -> None:
         main,
         ["validate-spec", "--merge", str(split_specs / "person.yaml"), str(split_specs / "org.yaml")],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     assert "ok" in result.output
 
 
@@ -412,7 +412,7 @@ def test_validate_spec_merge_emit_to_file(runner: CliRunner, split_specs: Path, 
             str(split_specs / "org.yaml"),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     assert emit_path.exists()
     emitted = yaml.safe_load(emit_path.read_text())
     assert "class_derivations" in emitted
@@ -431,7 +431,7 @@ def test_validate_spec_merge_emit_stdout(runner: CliRunner, split_specs: Path) -
             str(split_specs / "org.yaml"),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     output_after_ok = result.output.split("Merged spec: ok\n", 1)[1]
     emitted = yaml.safe_load(output_after_ok)
     assert "class_derivations" in emitted
@@ -453,7 +453,7 @@ def test_validate_spec_merge_emit_entity(runner: CliRunner, split_specs: Path, t
             str(split_specs / "org.yaml"),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
     emitted = yaml.safe_load(emit_path.read_text())
     cd_names = [cd["name"] for cd in emitted["class_derivations"]]
     assert cd_names == ["Person"]
@@ -466,4 +466,4 @@ def test_validate_spec_entity_without_merge_errors(runner: CliRunner, split_spec
         ["validate-spec", "--entity", "Person", str(split_specs / "person.yaml")],
     )
     assert result.exit_code == 1
-    assert "--merge" in result.stderr
+    assert "--merge" in result.output

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -19,7 +19,7 @@ TABULAR_TRANSFORM = TABULAR_TEST_DIR / "transform" / "person_to_agent.transform.
 @pytest.fixture
 def runner() -> CliRunner:
     """Command line interface test runner."""
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture
@@ -117,8 +117,8 @@ class TestMapDataTsv:
         )
         assert result.exit_code == 0
         # Output should contain transformed data
-        assert "label: Alice" in result.stdout
-        assert "label: Bob" in result.stdout
+        assert "label: Alice" in result.output
+        assert "label: Bob" in result.output
 
     def test_tsv_input_jsonl_output(
         self,
@@ -144,7 +144,7 @@ class TestMapDataTsv:
             ],
         )
         assert result.exit_code == 0
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        lines = [line for line in result.output.strip().split("\n") if line]
         assert len(lines) == 2  # Two rows in TSV
         # Each line should be valid JSON
         for line in lines:
@@ -176,7 +176,7 @@ class TestMapDataTsv:
             ],
         )
         assert result.exit_code == 0
-        lines = result.stdout.strip().split("\n")
+        lines = result.output.strip().split("\n")
         assert len(lines) == 3  # Header + 2 data rows
         # Check header
         assert "id" in lines[0]
@@ -212,7 +212,7 @@ class TestMapDataCsv:
             ],
         )
         assert result.exit_code == 0
-        data = json.loads(result.stdout)
+        data = json.loads(result.output)
         assert len(data) == 1
         assert data[0]["label"] == "Charlie"
 
@@ -240,7 +240,7 @@ class TestMapDataCsv:
             ],
         )
         assert result.exit_code == 0
-        lines = result.stdout.strip().split("\n")
+        lines = result.output.strip().split("\n")
         assert len(lines) == 2  # Header + 1 data row
         # Check comma separation
         assert "," in lines[0]
@@ -280,7 +280,7 @@ class TestMapDataDirectory:
             ],
         )
         assert result.exit_code == 0
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        lines = [line for line in result.output.strip().split("\n") if line]
         assert len(lines) >= 1
 
 
@@ -381,7 +381,7 @@ def test_additional_output_tsv_and_json(
             str(sample_tsv_data),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
     # Primary JSONL
     jsonl_lines = [line for line in primary.read_text().strip().split("\n") if line]
@@ -426,10 +426,10 @@ def test_additional_output_format_inferred(
             str(sample_tsv_data),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
     # stdout should have YAML
-    assert "label:" in result.stdout
+    assert "label:" in result.output
 
     # Additional JSONL file
     jsonl_lines = [line for line in extra_jsonl.read_text().strip().split("\n") if line]
@@ -464,10 +464,10 @@ def test_additional_output_stdout_primary(
             str(sample_tsv_data),
         ],
     )
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.output
 
     # stdout should have JSONL
-    stdout_lines = [line for line in result.stdout.strip().split("\n") if line]
+    stdout_lines = [line for line in result.output.strip().split("\n") if line]
     assert len(stdout_lines) == 2
 
     # Additional JSON file
@@ -503,7 +503,7 @@ class TestMapDataWithExistingTestData:
             ],
         )
         assert result.exit_code == 0
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        lines = [line for line in result.output.strip().split("\n") if line]
         assert len(lines) >= 1
         # Verify content
         first = json.loads(lines[0])
@@ -566,8 +566,8 @@ class TestTransformSpecEngine:
                 str(data_dir),
             ],
         )
-        assert result.exit_code == 0, result.stderr
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert result.exit_code == 0, result.output
+        lines = [line for line in result.output.strip().split("\n") if line]
         # One row from each derivation = 2 output lines
         assert len(lines) == 2
         objs = [json.loads(line) for line in lines]
@@ -606,8 +606,8 @@ class TestTransformSpecEngine:
                 str(data_dir),
             ],
         )
-        assert result.exit_code == 0, result.stderr
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert result.exit_code == 0, result.output
+        lines = [line for line in result.output.strip().split("\n") if line]
         # Only Person rows should appear (Organization is ignored)
         assert len(lines) == 1
         obj = json.loads(lines[0])
@@ -704,8 +704,8 @@ class TestContinueOnError:
         )
         assert result.exit_code == 1
         # Error summary should be in stderr
-        assert "2 transformation error(s)" in result.stderr
-        assert "slot_derivation=bad" in result.stderr
+        assert "2 transformation error(s)" in result.output
+        assert "slot_derivation=bad" in result.output
 
     def test_continue_on_error_no_errors_exits_0(
         self,
@@ -730,5 +730,5 @@ class TestContinueOnError:
             ],
         )
         assert result.exit_code == 0
-        lines = [line for line in result.stdout.strip().split("\n") if line]
+        lines = [line for line in result.output.strip().split("\n") if line]
         assert len(lines) == 2

--- a/tests/test_cli/test_cli_validate.py
+++ b/tests/test_cli/test_cli_validate.py
@@ -15,7 +15,7 @@ from tests import (
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 def test_validate_spec_valid_file(runner: CliRunner) -> None:
@@ -49,7 +49,7 @@ def test_validate_spec_invalid_file(runner: CliRunner, tmp_path) -> None:
     bad.write_text("not_a_real_field: oops\n")
     result = runner.invoke(main, ["validate-spec", str(bad)])
     assert result.exit_code == 1
-    assert "not_a_real_field" in result.stderr
+    assert "not_a_real_field" in result.output
 
 
 def test_validate_spec_non_mapping(runner: CliRunner, tmp_path) -> None:
@@ -58,7 +58,7 @@ def test_validate_spec_non_mapping(runner: CliRunner, tmp_path) -> None:
     bad.write_text("- item\n")
     result = runner.invoke(main, ["validate-spec", str(bad)])
     assert result.exit_code == 1
-    assert "mapping" in result.stderr.lower()
+    assert "mapping" in result.output.lower()
 
 
 def test_validate_spec_mixed_valid_invalid(runner: CliRunner, tmp_path) -> None:
@@ -68,7 +68,7 @@ def test_validate_spec_mixed_valid_invalid(runner: CliRunner, tmp_path) -> None:
     result = runner.invoke(main, ["validate-spec", str(FLATTENING_TR), str(bad)])
     assert result.exit_code == 1
     assert any(line.endswith(": ok") for line in result.output.splitlines())
-    assert "bogus_field" in result.stderr
+    assert "bogus_field" in result.output
 
 
 def test_validate_spec_appears_in_help(runner: CliRunner) -> None:
@@ -95,7 +95,7 @@ def test_validate_spec_with_schemas(runner: CliRunner) -> None:
             str(FLATTENING_TR),
         ],
     )
-    assert result.exit_code == 0, f"stderr: {result.stderr}"
+    assert result.exit_code == 0, f"stderr: {result.output}"
     assert "ok" in result.output
 
 
@@ -113,7 +113,7 @@ def test_validate_spec_semantic_errors(runner: CliRunner, tmp_path) -> None:
         ],
     )
     assert result.exit_code == 1
-    assert "NonExistentClass" in result.stderr
+    assert "NonExistentClass" in result.output
 
 
 def test_validate_spec_strict_flag(runner: CliRunner, tmp_path) -> None:
@@ -151,7 +151,7 @@ def test_validate_spec_strict_flag(runner: CliRunner, tmp_path) -> None:
         ],
     )
     assert result.exit_code == 1
-    assert "bogus_slot" in result.stderr
+    assert "bogus_slot" in result.output
 
 
 def test_validate_spec_no_warnings(runner: CliRunner, tmp_path) -> None:
@@ -175,7 +175,7 @@ def test_validate_spec_no_warnings(runner: CliRunner, tmp_path) -> None:
             str(spec),
         ],
     )
-    assert "bogus_slot" in result.stderr
+    assert "bogus_slot" in result.output
 
     # With --no-warnings: warnings suppressed
     result = runner.invoke(
@@ -188,5 +188,5 @@ def test_validate_spec_no_warnings(runner: CliRunner, tmp_path) -> None:
             str(spec),
         ],
     )
-    assert "bogus_slot" not in result.stderr
+    assert "bogus_slot" not in result.output
     assert result.exit_code == 0

--- a/tests/test_cli/test_click_compat.py
+++ b/tests/test_cli/test_click_compat.py
@@ -1,0 +1,23 @@
+"""Verify CliRunner calls are forward-compatible with click 8.3+."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def test_cli_runner_no_mix_stderr():
+    """No CliRunner call should pass mix_stderr keyword.
+
+    The ``mix_stderr`` parameter was removed in click 8.3+.
+    See https://github.com/linkml/linkml-map/issues/218.
+    """
+    test_dir = Path(__file__).parent
+    for py_file in test_dir.glob("*.py"):
+        if py_file.name == Path(__file__).name:
+            continue
+        source = py_file.read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.keyword) and node.arg == "mix_stderr":
+                pytest.fail(f"{py_file.name} uses removed 'mix_stderr' kwarg")


### PR DESCRIPTION
## Summary

Removes the deprecated `mix_stderr=False` parameter from all `CliRunner` instantiations to ensure forward compatibility with click 8.3+.

**Root Cause:** click 8.3 removed the `mix_stderr` parameter from `CliRunner.__init__()`. All test fixtures passing `mix_stderr=False` will raise `TypeError` once click 8.3+ enters the dependency tree.

**Changes:**
- `tests/test_cli/test_cli.py`: Removed `mix_stderr=False`, added `_strip_preflight()` helper to handle merged stdout/stderr
- `tests/test_cli/test_cli_validate.py`: Removed `mix_stderr=False`
- `tests/test_cli/test_cli_multi_spec.py`: Removed `mix_stderr=False`
- `tests/test_cli/test_cli_tabular.py`: Removed `mix_stderr=False`
- `tests/test_cli/test_click_compat.py`: New AST-based test ensuring no regressions

## Testing
- 82 CLI tests pass (0 failures)
- Added `test_click_compat.py` that statically verifies no `mix_stderr` kwargs exist

Closes #218