### PR TITLE
Add validate-spec --list-entities for spec entity discovery

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -628,9 +628,9 @@ def validate_spec_cmd(
         linkml-map validate-spec --list-entities specs/
     """
     if list_entities:
-        from linkml_map.utils.spec_merge import class_derivation_names, load_and_merge_specs
+        from linkml_map.utils.spec_merge import class_derivation_names
 
-        merged = load_and_merge_specs(spec_files)
+        merged = _merge_or_exit(spec_files)
         for name in sorted(set(class_derivation_names(merged))):
             click.echo(name)
         return
@@ -713,6 +713,23 @@ def _validate_spec_individual(
         raise SystemExit(1)
 
 
+def _merge_or_exit(spec_files: tuple[str, ...]) -> dict:
+    """Merge spec files, reporting expected load/merge failures cleanly.
+
+    Catches :class:`SpecMergeError` (no spec files found, conflicting
+    derivations) and exits with code 1 and the message on stderr, rather
+    than dumping a traceback for a condition we deliberately raise. Any
+    other exception propagates, since it signals an actual bug.
+    """
+    from linkml_map.utils.spec_merge import SpecMergeError, load_and_merge_specs
+
+    try:
+        return load_and_merge_specs(spec_files)
+    except SpecMergeError as err:
+        click.echo(str(err), err=True)
+        raise SystemExit(1) from err
+
+
 def _validate_spec_merged(
     spec_files: tuple[str, ...],
     *,
@@ -724,10 +741,9 @@ def _validate_spec_merged(
     no_warnings: bool = False,
 ) -> None:
     """Merge spec files, validate the result, optionally emit."""
-    from linkml_map.utils.spec_merge import load_and_merge_specs
     from linkml_map.validator import validate_spec
 
-    merged = load_and_merge_specs(spec_files)
+    merged = _merge_or_exit(spec_files)
 
     # Apply entity filter before validation so we only validate what
     # map-data --entity would actually execute.

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -586,6 +586,14 @@ def invert(
 )
 @click.option("--strict", is_flag=True, help="Treat warnings as errors.")
 @click.option("--no-warnings", is_flag=True, help="Suppress warning output.")
+@click.option(
+    "--list-entities",
+    is_flag=True,
+    default=False,
+    help="Print the class_derivation names from the merged spec (one per line, "
+    "sorted) and exit, skipping schema-binding validation.  For discovery by "
+    "external orchestrators before per-entity runs.",
+)
 def validate_spec_cmd(
     spec_files: tuple[str, ...],
     source_schema: str | None = None,
@@ -595,6 +603,7 @@ def validate_spec_cmd(
     entity: str | None = None,
     merge: bool = False,
     emit_spec: str | None = None,
+    list_entities: bool = False,
 ) -> None:
     """Validate transformation specification YAML files.
 
@@ -615,7 +624,17 @@ def validate_spec_cmd(
         linkml-map validate-spec specs/*.yaml
 
         linkml-map validate-spec --merge --entity Person --emit-spec resolved.yaml specs/
+
+        linkml-map validate-spec --list-entities specs/
     """
+    if list_entities:
+        from linkml_map.utils.spec_merge import class_derivation_names, load_and_merge_specs
+
+        merged = load_and_merge_specs(spec_files)
+        for name in sorted(set(class_derivation_names(merged))):
+            click.echo(name)
+        return
+
     if merge:
         _validate_spec_merged(
             spec_files,

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -713,7 +713,7 @@ def _validate_spec_individual(
         raise SystemExit(1)
 
 
-def _merge_or_exit(spec_files: tuple[str, ...]) -> dict:
+def _merge_or_exit(spec_files: tuple[str, ...]) -> dict[str, Any]:
     """Merge spec files, reporting expected load/merge failures cleanly.
 
     Catches :class:`SpecMergeError` (no spec files found, conflicting

--- a/src/linkml_map/utils/spec_merge.py
+++ b/src/linkml_map/utils/spec_merge.py
@@ -26,6 +26,17 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+class SpecMergeError(ValueError):
+    """Raised for expected, user-facing spec load/merge failures.
+
+    Distinguishes conditions we deliberately raise with a precise message
+    (no spec files found, conflicting derivations) from unexpected errors
+    that should still surface as a traceback. CLI callers catch this to
+    report the message cleanly instead of dumping a stack trace; subclassing
+    :class:`ValueError` keeps backward compatibility for existing handlers.
+    """
+
+
 def resolve_spec_paths(paths: tuple[str | Path, ...]) -> list[Path]:
     """Resolve a mix of file paths and directories to a flat list of YAML files.
 
@@ -89,7 +100,7 @@ def merge_spec_dicts(spec_dicts: list[dict[str, Any]]) -> dict[str, Any]:
 
     :param spec_dicts: A list of raw spec dicts to merge.
     :returns: A single merged spec dict.
-    :raises ValueError: If enum or slot derivations conflict on the same name.
+    :raises SpecMergeError: If enum or slot derivations conflict on the same name.
     """
     if not spec_dicts:
         return {}
@@ -119,7 +130,7 @@ def merge_spec_dicts(spec_dicts: list[dict[str, Any]]) -> dict[str, Any]:
             for name, body in ed.items():
                 if name in merged_enum_derivations and merged_enum_derivations[name] != body:
                     msg = f"Conflicting enum_derivations for '{name}'"
-                    raise ValueError(msg)
+                    raise SpecMergeError(msg)
                 merged_enum_derivations[name] = body
 
         # Union slot_derivations by name
@@ -128,7 +139,7 @@ def merge_spec_dicts(spec_dicts: list[dict[str, Any]]) -> dict[str, Any]:
             for name, body in sd.items():
                 if name in merged_slot_derivations and merged_slot_derivations[name] != body:
                     msg = f"Conflicting slot_derivations for '{name}'"
-                    raise ValueError(msg)
+                    raise SpecMergeError(msg)
                 merged_slot_derivations[name] = body
 
         # Scalar fields: first non-None wins
@@ -152,12 +163,12 @@ def load_and_merge_specs(paths: tuple[str | Path, ...]) -> dict[str, Any]:
     :param paths: File paths or directory paths to load.
     :returns: A single merged spec dict.
     :raises FileNotFoundError: If a path does not exist.
-    :raises ValueError: If no YAML files are found or derivations conflict.
+    :raises SpecMergeError: If no YAML files are found or derivations conflict.
     """
     file_paths = resolve_spec_paths(paths)
     if not file_paths:
         msg = "No YAML files found in the provided paths"
-        raise ValueError(msg)
+        raise SpecMergeError(msg)
 
     all_dicts: list[dict[str, Any]] = []
     for fp in file_paths:
@@ -165,7 +176,7 @@ def load_and_merge_specs(paths: tuple[str | Path, ...]) -> dict[str, Any]:
 
     if not all_dicts:
         msg = "No valid spec dicts found in the provided files"
-        raise ValueError(msg)
+        raise SpecMergeError(msg)
 
     return merge_spec_dicts(all_dicts)
 

--- a/src/linkml_map/utils/spec_merge.py
+++ b/src/linkml_map/utils/spec_merge.py
@@ -168,3 +168,39 @@ def load_and_merge_specs(paths: tuple[str | Path, ...]) -> dict[str, Any]:
         raise ValueError(msg)
 
     return merge_spec_dicts(all_dicts)
+
+
+def class_derivation_names(spec: dict[str, Any]) -> list[str]:
+    """Extract the class_derivation names from a (merged) spec dict.
+
+    Handles the three shapes ``class_derivations`` can take: a dict keyed by
+    name, a list of expanded dicts (``{"name": "X", ...}``), or a list of
+    compact single-key dicts (``{"X": {...}}``). Names are returned in
+    encounter order without deduplication; callers that want a sorted, unique
+    view (e.g. for display) apply ``sorted(set(...))`` themselves.
+
+    :param spec: A spec dict, typically the output of :func:`load_and_merge_specs`.
+    :returns: The class_derivation names in encounter order.
+
+    >>> class_derivation_names({"class_derivations": {"Person": {}, "Org": {}}})
+    ['Person', 'Org']
+    >>> class_derivation_names({"class_derivations": [{"name": "Person"}, {"name": "Org"}]})
+    ['Person', 'Org']
+    >>> class_derivation_names({"class_derivations": [{"Person": {}}, {"Org": {}}]})
+    ['Person', 'Org']
+    >>> class_derivation_names({})
+    []
+    """
+    cd = spec.get("class_derivations")
+    names: list[str] = []
+    if isinstance(cd, list):
+        for item in cd:
+            if not isinstance(item, dict):
+                continue
+            if "name" in item:  # expanded format
+                names.append(item["name"])
+            elif len(item) == 1:  # compact-key format
+                names.append(next(iter(item)))
+    elif isinstance(cd, dict):
+        names.extend(cd.keys())
+    return names

--- a/tests/test_cli/test_cli_multi_spec.py
+++ b/tests/test_cli/test_cli_multi_spec.py
@@ -496,3 +496,25 @@ def test_list_entities_multiple_files(runner: CliRunner, split_specs: Path) -> N
     )
     assert result.exit_code == 0, result.stderr
     assert [line for line in result.output.strip().split("\n") if line] == ["Org", "Person"]
+
+
+def test_list_entities_empty_dir_reports_cleanly(runner: CliRunner, tmp_path: Path) -> None:
+    """No specs found surfaces a clean message + exit 1, not a Python traceback."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = runner.invoke(main, ["validate-spec", "--list-entities", str(empty)])
+    assert result.exit_code == 1
+    assert "No YAML files" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_merge_conflict_reports_cleanly(runner: CliRunner, tmp_path: Path) -> None:
+    """A merge conflict surfaces SpecMergeError's message cleanly, not a traceback."""
+    spec_dir = tmp_path / "conflict"
+    spec_dir.mkdir()
+    (spec_dir / "a.yaml").write_text(yaml.dump({"slot_derivations": {"s1": {"populated_from": "x"}}}))
+    (spec_dir / "b.yaml").write_text(yaml.dump({"slot_derivations": {"s1": {"populated_from": "y"}}}))
+    result = runner.invoke(main, ["validate-spec", "--merge", str(spec_dir)])
+    assert result.exit_code == 1
+    assert "Conflicting slot_derivations" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/tests/test_cli/test_cli_multi_spec.py
+++ b/tests/test_cli/test_cli_multi_spec.py
@@ -467,3 +467,32 @@ def test_validate_spec_entity_without_merge_errors(runner: CliRunner, split_spec
     )
     assert result.exit_code == 1
     assert "--merge" in result.stderr
+
+
+# --- --list-entities tests ---
+
+
+def test_list_entities_prints_sorted_names(runner: CliRunner, split_specs: Path) -> None:
+    """--list-entities prints merged class_derivation names, sorted, one per line.
+
+    No schema is passed, proving it skips schema-binding validation.
+    """
+    result = runner.invoke(main, ["validate-spec", "--list-entities", str(split_specs)])
+    assert result.exit_code == 0, result.stderr
+    lines = [line for line in result.output.strip().split("\n") if line]
+    assert lines == ["Org", "Person"]
+
+
+def test_list_entities_multiple_files(runner: CliRunner, split_specs: Path) -> None:
+    """--list-entities discovers across multiple explicitly-listed spec files."""
+    result = runner.invoke(
+        main,
+        [
+            "validate-spec",
+            "--list-entities",
+            str(split_specs / "person.yaml"),
+            str(split_specs / "org.yaml"),
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    assert [line for line in result.output.strip().split("\n") if line] == ["Org", "Person"]

--- a/tests/test_utils/test_spec_merge.py
+++ b/tests/test_utils/test_spec_merge.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from linkml_map.utils.spec_merge import (
+    SpecMergeError,
     load_and_merge_specs,
     load_spec_file,
     merge_spec_dicts,
@@ -193,4 +194,12 @@ class TestLoadAndMergeSpecs:
         sub = tmp_path / "empty"
         sub.mkdir()
         with pytest.raises(ValueError, match="No YAML files"):
+            load_and_merge_specs((str(sub),))
+
+    def test_failure_is_spec_merge_error(self, tmp_path):
+        """Deliberate failures raise SpecMergeError (a ValueError subclass)."""
+        assert issubclass(SpecMergeError, ValueError)
+        sub = tmp_path / "empty"
+        sub.mkdir()
+        with pytest.raises(SpecMergeError, match="No YAML files"):
             load_and_merge_specs((str(sub),))


### PR DESCRIPTION
Adds `--list-entities` to `validate-spec`: merges the given spec files, prints the class_derivation names (sorted, one per line) to stdout, and exits — skipping schema-binding validation. Lets external orchestrators (Make, snakemake) discover entities before fanning out per-entity `map-data --entity` runs.

- Lifts a public `class_derivation_names(spec)` into `utils/spec_merge.py` (next to `load_and_merge_specs`); the CLI flag is a thin wrapper. dm-bip can import it and delete its local copy.
- Handles all three `class_derivations` shapes (dict-keyed, expanded list, compact-key list) via a doctest; CLI integration tests cover the flag.
- Positioned for #253 to absorb `class_derivation_names` into the lifted spec-operations API without touching the CLI surface.

Closes #243