### PR TITLE
Fill in missing description fields in transformer_model.yaml

### DIFF
--- a/docs/schema/AggregationOperation.md
+++ b/docs/schema/AggregationOperation.md
@@ -5,6 +5,11 @@ search:
 
 # Class: AggregationOperation 
 
+
+_An operation that reduces multiple input values to a single value using an aggregation function such as sum, average, or count._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -71,9 +76,9 @@ URI: [linkmlmap:AggregationOperation](https://w3id.org/linkml/transformer/Aggreg
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [operator](operator.md) | 1 <br/> [AggregationType](AggregationType.md) |  | direct |
-| [null_handling](null_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) |  | direct |
-| [invalid_value_handling](invalid_value_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) |  | direct |
+| [operator](operator.md) | 1 <br/> [AggregationType](AggregationType.md) | The aggregation function to apply (for example SUM, AVERAGE, COUNT) | direct |
+| [null_handling](null_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) | How to handle null values encountered during aggregation | direct |
+| [invalid_value_handling](invalid_value_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) | How to handle values that cannot be interpreted as valid input to the aggrega... | direct |
 
 
 
@@ -131,11 +136,14 @@ URI: [linkmlmap:AggregationOperation](https://w3id.org/linkml/transformer/Aggreg
 <details>
 ```yaml
 name: AggregationOperation
+description: An operation that reduces multiple input values to a single value using
+  an aggregation function such as sum, average, or count.
 from_schema: https://w3id.org/linkml/transformer
 is_a: TransformationOperation
 attributes:
   operator:
     name: operator
+    description: The aggregation function to apply (for example SUM, AVERAGE, COUNT).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -144,6 +152,7 @@ attributes:
     required: true
   null_handling:
     name: null_handling
+    description: How to handle null values encountered during aggregation.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -152,6 +161,8 @@ attributes:
     range: InvalidValueHandlingStrategy
   invalid_value_handling:
     name: invalid_value_handling
+    description: How to handle values that cannot be interpreted as valid input to
+      the aggregation.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -166,11 +177,14 @@ attributes:
 <details>
 ```yaml
 name: AggregationOperation
+description: An operation that reduces multiple input values to a single value using
+  an aggregation function such as sum, average, or count.
 from_schema: https://w3id.org/linkml/transformer
 is_a: TransformationOperation
 attributes:
   operator:
     name: operator
+    description: The aggregation function to apply (for example SUM, AVERAGE, COUNT).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: AggregationOperation
@@ -180,6 +194,7 @@ attributes:
     required: true
   null_handling:
     name: null_handling
+    description: How to handle null values encountered during aggregation.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: AggregationOperation
@@ -189,6 +204,8 @@ attributes:
     range: InvalidValueHandlingStrategy
   invalid_value_handling:
     name: invalid_value_handling
+    description: How to handle values that cannot be interpreted as valid input to
+      the aggregation.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: AggregationOperation

--- a/docs/schema/AggregationType.md
+++ b/docs/schema/AggregationType.md
@@ -36,7 +36,7 @@ URI: [linkmlmap:AggregationType](https://w3id.org/linkml/transformer/Aggregation
 
 | Name | Description |
 | ---  | --- |
-| [operator](operator.md) |  |
+| [operator](operator.md) | The aggregation function to apply (for example SUM, AVERAGE, COUNT) |
 
 
 

--- a/docs/schema/Any.md
+++ b/docs/schema/Any.md
@@ -5,6 +5,11 @@ search:
 
 # Class: Any 
 
+
+_A wildcard type that accepts any value. Used where the model deliberately avoids coupling to a specific range, such as embedded LinkML definition objects._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -109,6 +114,8 @@ URI: [linkml:Any](https://w3id.org/linkml/Any)
 <details>
 ```yaml
 name: Any
+description: A wildcard type that accepts any value. Used where the model deliberately
+  avoids coupling to a specific range, such as embedded LinkML definition objects.
 from_schema: https://w3id.org/linkml/transformer
 class_uri: linkml:Any
 
@@ -120,6 +127,8 @@ class_uri: linkml:Any
 <details>
 ```yaml
 name: Any
+description: A wildcard type that accepts any value. Used where the model deliberately
+  avoids coupling to a specific range, such as embedded LinkML definition objects.
 from_schema: https://w3id.org/linkml/transformer
 class_uri: linkml:Any
 

--- a/docs/schema/ClassDerivation.md
+++ b/docs/schema/ClassDerivation.md
@@ -193,19 +193,19 @@ URI: [linkmlmap:ClassDerivation](https://w3id.org/linkml/transformer/ClassDeriva
 | [populated_from](populated_from.md) | 0..1 <br/> [ClassReference](ClassReference.md) | Source class to derive this target class from | direct |
 | [sources](sources.md) | * <br/> [ClassReference](ClassReference.md) | Deprecated | direct |
 | [joins](joins.md) | * <br/> [AliasedClass](AliasedClass.md) | Additional classes to be joined to derive instances of the target class | direct |
-| [slot_derivations](slot_derivations.md) | * <br/> [SlotDerivation](SlotDerivation.md) |  | direct |
+| [slot_derivations](slot_derivations.md) | * <br/> [SlotDerivation](SlotDerivation.md) | Instructions on how to derive the slots of this target class from source data | direct |
 | [target_definition](target_definition.md) | 0..1 <br/> [Any](Any.md) | LinkML class definition object for this slot | direct |
 | [pivot_operation](pivot_operation.md) | 0..1 <br/> [PivotOperation](PivotOperation.md) | Configuration for pivot (unmelt) operations at class level | direct |
 | [name](name.md) | 1 <br/> [String](String.md) | Name of the element in the target schema | [ElementDerivation](ElementDerivation.md) |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -312,6 +312,8 @@ attributes:
     inlined: true
   slot_derivations:
     name: slot_derivations
+    description: Instructions on how to derive the slots of this target class from
+      source data.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - TransformationSpecification
@@ -395,6 +397,8 @@ attributes:
     inlined: true
   slot_derivations:
     name: slot_derivations
+    description: Instructions on how to derive the slots of this target class from
+      source data.
     from_schema: https://w3id.org/linkml/transformer
     owner: ClassDerivation
     domain_of:
@@ -443,6 +447,8 @@ attributes:
     required: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: ClassDerivation
     domain_of:
@@ -462,6 +468,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -471,6 +478,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -538,6 +546,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: ClassDerivation

--- a/docs/schema/CollectionType.md
+++ b/docs/schema/CollectionType.md
@@ -27,7 +27,7 @@ URI: [linkmlmap:CollectionType](https://w3id.org/linkml/transformer/CollectionTy
 
 | Name | Description |
 | ---  | --- |
-| [cast_collection_as](cast_collection_as.md) |  |
+| [cast_collection_as](cast_collection_as.md) | Coerce the derived slot's collection form (for example single-valued, list, o... |
 
 
 

--- a/docs/schema/CopyDirective.md
+++ b/docs/schema/CopyDirective.md
@@ -83,12 +83,12 @@ URI: [linkmlmap:CopyDirective](https://w3id.org/linkml/transformer/CopyDirective
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [element_name](element_name.md) | 1 <br/> [String](String.md) |  | direct |
+| [element_name](element_name.md) | 1 <br/> [String](String.md) | Name of the source element (class, slot, enum, etc | direct |
 | [copy_all](copy_all.md) | 0..1 <br/> [Boolean](Boolean.md) | Copy all sub-elements of the Element being derived | direct |
 | [exclude_all](exclude_all.md) | 0..1 <br/> [Boolean](Boolean.md) | Do not copy any of the sub-elements of the Element being derived | direct |
 | [exclude](exclude.md) | 0..1 <br/> [Any](Any.md) | Remove certain sub-elements from the list of sub-elements to be copied | direct |
 | [include](include.md) | 0..1 <br/> [Any](Any.md) | Add certain sub-elements to the list of sub-elements to be copied | direct |
-| [add](add.md) | 0..1 <br/> [Any](Any.md) |  | direct |
+| [add](add.md) | 0..1 <br/> [Any](Any.md) | Add new sub-elements that are not present in the source element | direct |
 
 
 
@@ -181,6 +181,8 @@ status: testing
 attributes:
   element_name:
     name: element_name
+    description: Name of the source element (class, slot, enum, etc.) this directive
+      applies to.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true
@@ -229,6 +231,8 @@ attributes:
     range: Any
   add:
     name: add
+    description: 'Add new sub-elements that are not present in the source element.
+      Currently under-specified and not yet implemented (see issue #245).'
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -267,6 +271,8 @@ status: testing
 attributes:
   element_name:
     name: element_name
+    description: Name of the source element (class, slot, enum, etc.) this directive
+      applies to.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true
@@ -321,6 +327,8 @@ attributes:
     range: Any
   add:
     name: add
+    description: 'Add new sub-elements that are not present in the source element.
+      Currently under-specified and not yet implemented (see issue #245).'
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: CopyDirective

--- a/docs/schema/CopyDirective.md
+++ b/docs/schema/CopyDirective.md
@@ -83,7 +83,7 @@ URI: [linkmlmap:CopyDirective](https://w3id.org/linkml/transformer/CopyDirective
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [element_name](element_name.md) | 1 <br/> [String](String.md) | Name of the source element (class, slot, enum, etc | direct |
+| [element_name](element_name.md) | 1 <br/> [String](String.md) | Name of the source element this directive applies to (a class, slot, enum, et... | direct |
 | [copy_all](copy_all.md) | 0..1 <br/> [Boolean](Boolean.md) | Copy all sub-elements of the Element being derived | direct |
 | [exclude_all](exclude_all.md) | 0..1 <br/> [Boolean](Boolean.md) | Do not copy any of the sub-elements of the Element being derived | direct |
 | [exclude](exclude.md) | 0..1 <br/> [Any](Any.md) | Remove certain sub-elements from the list of sub-elements to be copied | direct |
@@ -181,8 +181,8 @@ status: testing
 attributes:
   element_name:
     name: element_name
-    description: Name of the source element (class, slot, enum, etc.) this directive
-      applies to.
+    description: Name of the source element this directive applies to (a class, slot,
+      enum, etc.).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true
@@ -271,8 +271,8 @@ status: testing
 attributes:
   element_name:
     name: element_name
-    description: Name of the source element (class, slot, enum, etc.) this directive
-      applies to.
+    description: Name of the source element this directive applies to (a class, slot,
+      enum, etc.).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true

--- a/docs/schema/ElementDerivation.md
+++ b/docs/schema/ElementDerivation.md
@@ -165,15 +165,15 @@ URI: [linkmlmap:ElementDerivation](https://w3id.org/linkml/transformer/ElementDe
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [name](name.md) | 1 <br/> [String](String.md) | Name of the element in the target schema | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | direct |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | direct |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | direct |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | direct |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | direct |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | direct |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | direct |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | direct |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | direct |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | direct |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | direct |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | direct |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | direct |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -268,6 +268,8 @@ attributes:
     - Agent
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - TransformationSpecification
@@ -285,6 +287,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -293,6 +296,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -355,6 +359,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -392,6 +398,8 @@ attributes:
     required: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: ElementDerivation
     domain_of:
@@ -411,6 +419,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -420,6 +429,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -487,6 +497,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: ElementDerivation

--- a/docs/schema/EnumDerivation.md
+++ b/docs/schema/EnumDerivation.md
@@ -167,15 +167,15 @@ URI: [linkmlmap:EnumDerivation](https://w3id.org/linkml/transformer/EnumDerivati
 | [expr](expr.md) | 0..1 <br/> [String](String.md) | An expression to be evaluated on the source object to derive the target slot | direct |
 | [hide](hide.md) | 0..1 <br/> [Boolean](Boolean.md) | True if this is suppressed | direct |
 | [permissible_value_derivations](permissible_value_derivations.md) | * <br/> [PermissibleValueDerivation](PermissibleValueDerivation.md) | Instructions on how to derive a set of PVs in the target schema | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -394,6 +394,8 @@ attributes:
     inlined: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: EnumDerivation
     domain_of:
@@ -413,6 +415,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -422,6 +425,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -489,6 +493,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: EnumDerivation

--- a/docs/schema/GroupingOperation.md
+++ b/docs/schema/GroupingOperation.md
@@ -5,6 +5,11 @@ search:
 
 # Class: GroupingOperation 
 
+
+_An operation that groups source rows prior to aggregation._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -49,7 +54,7 @@ URI: [linkmlmap:GroupingOperation](https://w3id.org/linkml/transformer/GroupingO
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [null_handling](null_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) |  | direct |
+| [null_handling](null_handling.md) | 0..1 <br/> [InvalidValueHandlingStrategy](InvalidValueHandlingStrategy.md) | How to handle null values when grouping | direct |
 
 
 
@@ -100,11 +105,13 @@ URI: [linkmlmap:GroupingOperation](https://w3id.org/linkml/transformer/GroupingO
 <details>
 ```yaml
 name: GroupingOperation
+description: An operation that groups source rows prior to aggregation.
 from_schema: https://w3id.org/linkml/transformer
 is_a: TransformationOperation
 attributes:
   null_handling:
     name: null_handling
+    description: How to handle null values when grouping.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - AggregationOperation
@@ -119,11 +126,13 @@ attributes:
 <details>
 ```yaml
 name: GroupingOperation
+description: An operation that groups source rows prior to aggregation.
 from_schema: https://w3id.org/linkml/transformer
 is_a: TransformationOperation
 attributes:
   null_handling:
     name: null_handling
+    description: How to handle null values when grouping.
     from_schema: https://w3id.org/linkml/transformer
     owner: GroupingOperation
     domain_of:

--- a/docs/schema/InvalidValueHandlingStrategy.md
+++ b/docs/schema/InvalidValueHandlingStrategy.md
@@ -26,8 +26,8 @@ URI: [linkmlmap:InvalidValueHandlingStrategy](https://w3id.org/linkml/transforme
 
 | Name | Description |
 | ---  | --- |
-| [null_handling](null_handling.md) |  |
-| [invalid_value_handling](invalid_value_handling.md) |  |
+| [null_handling](null_handling.md) | How to handle null values encountered during aggregation |
+| [invalid_value_handling](invalid_value_handling.md) | How to handle values that cannot be interpreted as valid input to the aggrega... |
 
 
 

--- a/docs/schema/Inverse.md
+++ b/docs/schema/Inverse.md
@@ -40,8 +40,8 @@ URI: [linkmlmap:Inverse](https://w3id.org/linkml/transformer/Inverse)
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [slot_name](slot_name.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [class_name](class_name.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [slot_name](slot_name.md) | 0..1 <br/> [String](String.md) | Name of the slot on the referenced class that back-references the derived slo... | direct |
+| [class_name](class_name.md) | 0..1 <br/> [String](String.md) | Name of the class that holds the back-reference (foreign key) slot | direct |
 
 
 
@@ -113,12 +113,15 @@ aliases:
 attributes:
   slot_name:
     name: slot_name
+    description: Name of the slot on the referenced class that back-references the
+      derived slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - Inverse
   class_name:
     name: class_name
+    description: Name of the class that holds the back-reference (foreign key) slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -140,6 +143,8 @@ aliases:
 attributes:
   slot_name:
     name: slot_name
+    description: Name of the slot on the referenced class that back-references the
+      derived slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: Inverse
@@ -147,6 +152,7 @@ attributes:
     - Inverse
   class_name:
     name: class_name
+    description: Name of the class that holds the back-reference (foreign key) slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: Inverse

--- a/docs/schema/KeyVal.md
+++ b/docs/schema/KeyVal.md
@@ -5,6 +5,11 @@ search:
 
 # Class: KeyVal 
 
+
+_A generic key-value pair._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -44,8 +49,8 @@ URI: [linkmlmap:KeyVal](https://w3id.org/linkml/transformer/KeyVal)
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [key](key.md) | 1 <br/> [String](String.md) |  | direct |
-| [value](value.md) | 0..1 <br/> [Any](Any.md) |  | direct |
+| [key](key.md) | 1 <br/> [String](String.md) | The key | direct |
+| [value](value.md) | 0..1 <br/> [Any](Any.md) | The value associated with the key | direct |
 
 
 
@@ -131,10 +136,12 @@ URI: [linkmlmap:KeyVal](https://w3id.org/linkml/transformer/KeyVal)
 <details>
 ```yaml
 name: KeyVal
+description: A generic key-value pair.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   key:
     name: key
+    description: The key.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true
@@ -142,6 +149,7 @@ attributes:
     - KeyVal
   value:
     name: value
+    description: The value associated with the key.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - SlotDerivation
@@ -156,10 +164,12 @@ attributes:
 <details>
 ```yaml
 name: KeyVal
+description: A generic key-value pair.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   key:
     name: key
+    description: The key.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     key: true
@@ -169,6 +179,7 @@ attributes:
     required: true
   value:
     name: value
+    description: The value associated with the key.
     from_schema: https://w3id.org/linkml/transformer
     owner: KeyVal
     domain_of:

--- a/docs/schema/ObjectDerivation.md
+++ b/docs/schema/ObjectDerivation.md
@@ -154,16 +154,16 @@ URI: [linkmlmap:ObjectDerivation](https://w3id.org/linkml/transformer/ObjectDeri
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [name](name.md) | 0..1 <br/> [String](String.md) | Name of the element in the target schema | direct |
-| [class_derivations](class_derivations.md) | * <br/> [ClassDerivation](ClassDerivation.md) |  | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [class_derivations](class_derivations.md) | * <br/> [ClassDerivation](ClassDerivation.md) | Class derivations used to construct nested instances for this (deprecated) ob... | direct |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -246,6 +246,8 @@ attributes:
     required: false
   class_derivations:
     name: class_derivations
+    description: Class derivations used to construct nested instances for this (deprecated)
+      object derivation.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - TransformationSpecification
@@ -286,6 +288,8 @@ attributes:
     required: false
   class_derivations:
     name: class_derivations
+    description: Class derivations used to construct nested instances for this (deprecated)
+      object derivation.
     from_schema: https://w3id.org/linkml/transformer
     owner: ObjectDerivation
     domain_of:
@@ -297,6 +301,8 @@ attributes:
     inlined: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: ObjectDerivation
     domain_of:
@@ -316,6 +322,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -325,6 +332,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -392,6 +400,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: ObjectDerivation

--- a/docs/schema/PermissibleValueDerivation.md
+++ b/docs/schema/PermissibleValueDerivation.md
@@ -151,19 +151,19 @@ URI: [linkmlmap:PermissibleValueDerivation](https://w3id.org/linkml/transformer/
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [name](name.md) | 1 <br/> [String](String.md) | Target permissible value text | direct |
-| [expr](expr.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [expr](expr.md) | 0..1 <br/> [String](String.md) | An expression evaluated on the source object to derive this permissible value | direct |
 | [populated_from](populated_from.md) | 0..1 <br/> [String](String.md) | Source permissible value that maps to this target permissible value | direct |
 | [sources](sources.md) | * <br/> [String](String.md) | Deprecated | direct |
-| [hide](hide.md) | 0..1 <br/> [Boolean](Boolean.md) |  | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [hide](hide.md) | 0..1 <br/> [Boolean](Boolean.md) | True if this is suppressed | direct |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -249,6 +249,8 @@ attributes:
     - Agent
   expr:
     name: expr
+    description: An expression evaluated on the source object to derive this permissible
+      value. Should be specified using the LinkML expression language.
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - SlotDerivation
@@ -280,6 +282,7 @@ attributes:
     multivalued: true
   hide:
     name: hide
+    description: True if this is suppressed
     from_schema: https://w3id.org/linkml/transformer
     domain_of:
     - SlotDerivation
@@ -318,6 +321,8 @@ attributes:
     required: true
   expr:
     name: expr
+    description: An expression evaluated on the source object to derive this permissible
+      value. Should be specified using the LinkML expression language.
     from_schema: https://w3id.org/linkml/transformer
     owner: PermissibleValueDerivation
     domain_of:
@@ -352,6 +357,7 @@ attributes:
     multivalued: true
   hide:
     name: hide
+    description: True if this is suppressed
     from_schema: https://w3id.org/linkml/transformer
     owner: PermissibleValueDerivation
     domain_of:
@@ -361,6 +367,8 @@ attributes:
     range: boolean
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: PermissibleValueDerivation
     domain_of:
@@ -380,6 +388,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -389,6 +398,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -456,6 +466,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: PermissibleValueDerivation

--- a/docs/schema/PivotDirectionType.md
+++ b/docs/schema/PivotDirectionType.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:PivotDirectionType](https://w3id.org/linkml/transformer/PivotDir
 
 | Name | Description |
 | ---  | --- |
-| [direction](direction.md) |  |
+| [direction](direction.md) | Whether to MELT (wide to long) or UNMELT (long to wide) |
 
 
 

--- a/docs/schema/PivotOperation.md
+++ b/docs/schema/PivotOperation.md
@@ -5,6 +5,11 @@ search:
 
 # Class: PivotOperation 
 
+
+_An operation that reshapes data between wide and long (EAV) representations, i.e. melt (wide to long) and unmelt (long to wide)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -65,11 +70,11 @@ URI: [linkmlmap:PivotOperation](https://w3id.org/linkml/transformer/PivotOperati
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [direction](direction.md) | 1 <br/> [PivotDirectionType](PivotDirectionType.md) |  | direct |
+| [direction](direction.md) | 1 <br/> [PivotDirectionType](PivotDirectionType.md) | Whether to MELT (wide to long) or UNMELT (long to wide) | direct |
 | [variable_slot](variable_slot.md) | 0..1 <br/> [SlotReference](SlotReference.md) | Slot to use for the variable column in the melted/long representation | direct |
 | [value_slot](value_slot.md) | 0..1 <br/> [SlotReference](SlotReference.md) | Slot to use for the value column in the melted/long representation | direct |
 | [unmelt_to_class](unmelt_to_class.md) | 0..1 <br/> [ClassReference](ClassReference.md) | In an unmelt operation, attributes (which are values in the long/melted/EAV r... | direct |
-| [unmelt_to_slots](unmelt_to_slots.md) | * <br/> [SlotReference](SlotReference.md) |  | direct |
+| [unmelt_to_slots](unmelt_to_slots.md) | * <br/> [SlotReference](SlotReference.md) | For an unmelt operation, the target wide-format slots to populate from the lo... | direct |
 | [unit_slot](unit_slot.md) | 0..1 <br/> [SlotReference](SlotReference.md) | Optional slot containing unit information for {variable}_{unit} naming | direct |
 | [slot_name_template](slot_name_template.md) | 0..1 <br/> [String](String.md) | Template for generating target slot names | direct |
 | [source_slots](source_slots.md) | * <br/> [SlotReference](SlotReference.md) | For MELT, the list of wide-format slots to melt | direct |
@@ -138,6 +143,8 @@ URI: [linkmlmap:PivotOperation](https://w3id.org/linkml/transformer/PivotOperati
 <details>
 ```yaml
 name: PivotOperation
+description: An operation that reshapes data between wide and long (EAV) representations,
+  i.e. melt (wide to long) and unmelt (long to wide).
 from_schema: https://w3id.org/linkml/transformer
 aliases:
 - melt/unmelt
@@ -146,6 +153,7 @@ is_a: TransformationOperation
 attributes:
   direction:
     name: direction
+    description: Whether to MELT (wide to long) or UNMELT (long to wide).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -187,6 +195,8 @@ attributes:
     range: ClassReference
   unmelt_to_slots:
     name: unmelt_to_slots
+    description: For an unmelt operation, the target wide-format slots to populate
+      from the long/EAV rows.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -238,6 +248,8 @@ attributes:
 <details>
 ```yaml
 name: PivotOperation
+description: An operation that reshapes data between wide and long (EAV) representations,
+  i.e. melt (wide to long) and unmelt (long to wide).
 from_schema: https://w3id.org/linkml/transformer
 aliases:
 - melt/unmelt
@@ -246,6 +258,7 @@ is_a: TransformationOperation
 attributes:
   direction:
     name: direction
+    description: Whether to MELT (wide to long) or UNMELT (long to wide).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: PivotOperation
@@ -291,6 +304,8 @@ attributes:
     range: ClassReference
   unmelt_to_slots:
     name: unmelt_to_slots
+    description: For an unmelt operation, the target wide-format slots to populate
+      from the long/EAV rows.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: PivotOperation

--- a/docs/schema/PrefixDerivation.md
+++ b/docs/schema/PrefixDerivation.md
@@ -5,6 +5,11 @@ search:
 
 # Class: PrefixDerivation 
 
+
+_A specification of how to derive a target prefix declaration. Currently a placeholder with no additional fields._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -138,15 +143,15 @@ URI: [linkmlmap:PrefixDerivation](https://w3id.org/linkml/transformer/PrefixDeri
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
 | [name](name.md) | 1 <br/> [String](String.md) | Name of the element in the target schema | [ElementDerivation](ElementDerivation.md) |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -200,6 +205,8 @@ URI: [linkmlmap:PrefixDerivation](https://w3id.org/linkml/transformer/PrefixDeri
 <details>
 ```yaml
 name: PrefixDerivation
+description: A specification of how to derive a target prefix declaration. Currently
+  a placeholder with no additional fields.
 from_schema: https://w3id.org/linkml/transformer
 is_a: ElementDerivation
 
@@ -211,6 +218,8 @@ is_a: ElementDerivation
 <details>
 ```yaml
 name: PrefixDerivation
+description: A specification of how to derive a target prefix declaration. Currently
+  a placeholder with no additional fields.
 from_schema: https://w3id.org/linkml/transformer
 is_a: ElementDerivation
 attributes:
@@ -232,6 +241,8 @@ attributes:
     required: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: PrefixDerivation
     domain_of:
@@ -251,6 +262,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -260,6 +272,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -327,6 +340,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: PrefixDerivation

--- a/docs/schema/SerializationSyntaxType.md
+++ b/docs/schema/SerializationSyntaxType.md
@@ -26,7 +26,7 @@ URI: [linkmlmap:SerializationSyntaxType](https://w3id.org/linkml/transformer/Ser
 
 | Name | Description |
 | ---  | --- |
-| [syntax](syntax.md) |  |
+| [syntax](syntax.md) | Serialization syntax used to stringify the values when no delimiter is given |
 
 
 

--- a/docs/schema/SlotDerivation.md
+++ b/docs/schema/SlotDerivation.md
@@ -287,27 +287,27 @@ URI: [linkmlmap:SlotDerivation](https://w3id.org/linkml/transformer/SlotDerivati
 | [derived_from](derived_from.md) | * <br/> [SlotReference](SlotReference.md) | Deprecated | direct |
 | [expr](expr.md) | 0..1 <br/> [String](String.md) | An expression to be evaluated on the source object to derive the target slot | direct |
 | [value](value.md) | 0..1 <br/> [Any](Any.md) | A constant value to assign to the target slot | direct |
-| [range](range.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [unit_conversion](unit_conversion.md) | 0..1 <br/> [UnitConversionConfiguration](UnitConversionConfiguration.md) |  | direct |
+| [range](range.md) | 0..1 <br/> [String](String.md) | The range (value type) to assign to the derived target slot, overriding the r... | direct |
+| [unit_conversion](unit_conversion.md) | 0..1 <br/> [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting the source value's unit of measure when deriving... | direct |
 | [inverse_of](inverse_of.md) | 0..1 <br/> [Inverse](Inverse.md) | Used to specify a class-slot tuple that is the inverse of the derived/target ... | direct |
 | [hide](hide.md) | 0..1 <br/> [Boolean](Boolean.md) | True if this is suppressed | direct |
-| [type_designator](type_designator.md) | 0..1 <br/> [Boolean](Boolean.md) |  | direct |
+| [type_designator](type_designator.md) | 0..1 <br/> [Boolean](Boolean.md) | True if this target slot designates the type (class) of the instance, analogo... | direct |
 | [target_definition](target_definition.md) | 0..1 <br/> [Any](Any.md) | LinkML definition object for this slot | direct |
-| [cast_collection_as](cast_collection_as.md) | 0..1 <br/> [CollectionType](CollectionType.md) |  | direct |
-| [dictionary_key](dictionary_key.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [stringification](stringification.md) | 0..1 <br/> [StringificationConfiguration](StringificationConfiguration.md) |  | direct |
-| [aggregation_operation](aggregation_operation.md) | 0..1 <br/> [AggregationOperation](AggregationOperation.md) |  | direct |
+| [cast_collection_as](cast_collection_as.md) | 0..1 <br/> [CollectionType](CollectionType.md) | Coerce the derived slot's collection form (for example single-valued, list, o... | direct |
+| [dictionary_key](dictionary_key.md) | 0..1 <br/> [String](String.md) | When the derived value is a list of objects, the slot whose value is used as ... | direct |
+| [stringification](stringification.md) | 0..1 <br/> [StringificationConfiguration](StringificationConfiguration.md) | Configuration for combining multiple values into a single string value | direct |
+| [aggregation_operation](aggregation_operation.md) | 0..1 <br/> [AggregationOperation](AggregationOperation.md) | An aggregation operation that reduces multiple source values into this slot's... | direct |
 | [pivot_operation](pivot_operation.md) | 0..1 <br/> [PivotOperation](PivotOperation.md) | Configuration for pivot (melt) operations producing this slot | direct |
 | [offset](offset.md) | 0..1 <br/> [Offset](Offset.md) | Configuration for calculating a value by applying an offset to a baseline val... | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which sub-elements of the source element are copied in... | [ElementDerivation](ElementDerivation.md) |
 | [overrides](overrides.md) | 0..1 <br/> [Any](Any.md) | overrides source schema slots | [ElementDerivation](ElementDerivation.md) |
-| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
-| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [is_a](is_a.md) | 0..1 <br/> [ElementDerivation](ElementDerivation.md) | The parent element that the derived target element inherits from | [ElementDerivation](ElementDerivation.md) |
+| [mixins](mixins.md) | * <br/> [ElementDerivation](ElementDerivation.md) | Mixin elements applied to the derived target element | [ElementDerivation](ElementDerivation.md) |
 | [value_mappings](value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table that is applied directly to mappings, in order of precedence | [ElementDerivation](ElementDerivation.md) |
 | [expression_mappings](expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table where the values are expressions evaluated against source bin... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_value_mappings](expression_to_value_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys are boolean expressions and the values are ... | [ElementDerivation](ElementDerivation.md) |
 | [expression_to_expression_mappings](expression_to_expression_mappings.md) | * <br/> [KeyVal](KeyVal.md) | A mapping table in which the keys and values are expressions | [ElementDerivation](ElementDerivation.md) |
-| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) |  | [ElementDerivation](ElementDerivation.md) |
+| [mirror_source](mirror_source.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, pass the source value through unchanged instead of transforming it | [ElementDerivation](ElementDerivation.md) |
 | [description](description.md) | 0..1 <br/> [String](String.md) | description of the specification component | [SpecificationComponent](SpecificationComponent.md) |
 | [implements](implements.md) | * <br/> [Uriorcurie](Uriorcurie.md) | A reference to a specification that this component implements | [SpecificationComponent](SpecificationComponent.md) |
 | [comments](comments.md) | * <br/> [String](String.md) | A list of comments about this component | [SpecificationComponent](SpecificationComponent.md) |
@@ -475,6 +475,8 @@ attributes:
     range: Any
   range:
     name: range
+    description: The range (value type) to assign to the derived target slot, overriding
+      the range inferred from the source.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:range
@@ -483,6 +485,8 @@ attributes:
     range: string
   unit_conversion:
     name: unit_conversion
+    description: Configuration for converting the source value's unit of measure when
+      deriving this slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -512,6 +516,8 @@ attributes:
     range: boolean
   type_designator:
     name: type_designator
+    description: True if this target slot designates the type (class) of the instance,
+      analogous to LinkML's designates_type.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -529,6 +535,8 @@ attributes:
     range: Any
   cast_collection_as:
     name: cast_collection_as
+    description: Coerce the derived slot's collection form (for example single-valued,
+      list, or dictionary).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -536,6 +544,8 @@ attributes:
     range: CollectionType
   dictionary_key:
     name: dictionary_key
+    description: When the derived value is a list of objects, the slot whose value
+      is used as the key to index them into a dictionary.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -543,6 +553,8 @@ attributes:
     range: string
   stringification:
     name: stringification
+    description: Configuration for combining multiple values into a single string
+      value.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -550,6 +562,8 @@ attributes:
     range: StringificationConfiguration
   aggregation_operation:
     name: aggregation_operation
+    description: An aggregation operation that reduces multiple source values into
+      this slot's value.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -699,6 +713,8 @@ attributes:
     range: Any
   range:
     name: range
+    description: The range (value type) to assign to the derived target slot, overriding
+      the range inferred from the source.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:range
@@ -708,6 +724,8 @@ attributes:
     range: string
   unit_conversion:
     name: unit_conversion
+    description: Configuration for converting the source value's unit of measure when
+      deriving this slot.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -740,6 +758,8 @@ attributes:
     range: boolean
   type_designator:
     name: type_designator
+    description: True if this target slot designates the type (class) of the instance,
+      analogous to LinkML's designates_type.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -759,6 +779,8 @@ attributes:
     range: Any
   cast_collection_as:
     name: cast_collection_as
+    description: Coerce the derived slot's collection form (for example single-valued,
+      list, or dictionary).
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -767,6 +789,8 @@ attributes:
     range: CollectionType
   dictionary_key:
     name: dictionary_key
+    description: When the derived value is a list of objects, the slot whose value
+      is used as the key to index them into a dictionary.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -775,6 +799,8 @@ attributes:
     range: string
   stringification:
     name: stringification
+    description: Configuration for combining multiple values into a single string
+      value.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -783,6 +809,8 @@ attributes:
     range: StringificationConfiguration
   aggregation_operation:
     name: aggregation_operation
+    description: An aggregation operation that reduces multiple source values into
+      this slot's value.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation
@@ -813,6 +841,8 @@ attributes:
     range: Offset
   copy_directives:
     name: copy_directives
+    description: Directives controlling which sub-elements of the source element are
+      copied into the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     owner: SlotDerivation
     domain_of:
@@ -832,6 +862,7 @@ attributes:
     range: Any
   is_a:
     name: is_a
+    description: The parent element that the derived target element inherits from.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:is_a
@@ -841,6 +872,7 @@ attributes:
     range: ElementDerivation
   mixins:
     name: mixins
+    description: Mixin elements applied to the derived target element.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     slot_uri: linkml:mixins
@@ -908,6 +940,8 @@ attributes:
     inlined: true
   mirror_source:
     name: mirror_source
+    description: If true, pass the source value through unchanged instead of transforming
+      it.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: SlotDerivation

--- a/docs/schema/StringificationConfiguration.md
+++ b/docs/schema/StringificationConfiguration.md
@@ -5,6 +5,11 @@ search:
 
 # Class: StringificationConfiguration 
 
+
+_Configuration for collapsing multiple values into a single delimited or serialized string value._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -48,10 +53,10 @@ URI: [linkmlmap:StringificationConfiguration](https://w3id.org/linkml/transforme
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [delimiter](delimiter.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [reversed](reversed.md) | 0..1 <br/> [Boolean](Boolean.md) |  | direct |
-| [over_slots](over_slots.md) | * <br/> [String](String.md) |  | direct |
-| [syntax](syntax.md) | 0..1 <br/> [SerializationSyntaxType](SerializationSyntaxType.md) |  | direct |
+| [delimiter](delimiter.md) | 0..1 <br/> [String](String.md) | Delimiter used to join multiple values into a single string | direct |
+| [reversed](reversed.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, reverse the operation, splitting a delimited or serialized string ba... | direct |
+| [over_slots](over_slots.md) | * <br/> [String](String.md) | The source slots whose values are combined into the stringified result | direct |
+| [syntax](syntax.md) | 0..1 <br/> [SerializationSyntaxType](SerializationSyntaxType.md) | Serialization syntax used to stringify the values when no delimiter is given | direct |
 
 
 
@@ -109,10 +114,13 @@ URI: [linkmlmap:StringificationConfiguration](https://w3id.org/linkml/transforme
 <details>
 ```yaml
 name: StringificationConfiguration
+description: Configuration for collapsing multiple values into a single delimited
+  or serialized string value.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   delimiter:
     name: delimiter
+    description: Delimiter used to join multiple values into a single string.
     examples:
     - value: ','
     - value: '|'
@@ -124,6 +132,8 @@ attributes:
     range: string
   reversed:
     name: reversed
+    description: If true, reverse the operation, splitting a delimited or serialized
+      string back into multiple values.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -131,6 +141,7 @@ attributes:
     range: boolean
   over_slots:
     name: over_slots
+    description: The source slots whose values are combined into the stringified result.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -139,6 +150,8 @@ attributes:
     multivalued: true
   syntax:
     name: syntax
+    description: Serialization syntax used to stringify the values when no delimiter
+      is given.
     examples:
     - value: json
     - value: yaml
@@ -156,10 +169,13 @@ attributes:
 <details>
 ```yaml
 name: StringificationConfiguration
+description: Configuration for collapsing multiple values into a single delimited
+  or serialized string value.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   delimiter:
     name: delimiter
+    description: Delimiter used to join multiple values into a single string.
     examples:
     - value: ','
     - value: '|'
@@ -172,6 +188,8 @@ attributes:
     range: string
   reversed:
     name: reversed
+    description: If true, reverse the operation, splitting a delimited or serialized
+      string back into multiple values.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: StringificationConfiguration
@@ -180,6 +198,7 @@ attributes:
     range: boolean
   over_slots:
     name: over_slots
+    description: The source slots whose values are combined into the stringified result.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: StringificationConfiguration
@@ -189,6 +208,8 @@ attributes:
     multivalued: true
   syntax:
     name: syntax
+    description: Serialization syntax used to stringify the values when no delimiter
+      is given.
     examples:
     - value: json
     - value: yaml

--- a/docs/schema/TransformationSpecification.md
+++ b/docs/schema/TransformationSpecification.md
@@ -199,7 +199,7 @@ URI: [linkmlmap:TransformationSpecification](https://w3id.org/linkml/transformer
 | [license](license.md) | 0..1 <br/> [Uriorcurie](Uriorcurie.md) | license under which this transformation specification is published | direct |
 | [version](version.md) | 0..1 <br/> [String](String.md) | version of this transformation specification | direct |
 | [prefixes](prefixes.md) | * <br/> [KeyVal](KeyVal.md) | maps prefixes to URL expansions | direct |
-| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) |  | direct |
+| [copy_directives](copy_directives.md) | * <br/> [CopyDirective](CopyDirective.md) | Directives controlling which elements of the source schema are copied into th... | direct |
 | [source_schema](source_schema.md) | 0..1 <br/> [SchemaReference](SchemaReference.md) | Reference to the schema that describes the source (input) objects | direct |
 | [target_schema](target_schema.md) | 0..1 <br/> [SchemaReference](SchemaReference.md) | Reference to the schema that describes the target (output) objects | direct |
 | [source_schema_patches](source_schema_patches.md) | 0..1 <br/> [Any](Any.md) | Schema patches to apply to the source schema before transformation | direct |
@@ -328,6 +328,8 @@ attributes:
     inlined: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which elements of the source schema are copied
+      into the target schema.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -542,6 +544,8 @@ attributes:
     inlined: true
   copy_directives:
     name: copy_directives
+    description: Directives controlling which elements of the source schema are copied
+      into the target schema.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: TransformationSpecification

--- a/docs/schema/UnitConversionConfiguration.md
+++ b/docs/schema/UnitConversionConfiguration.md
@@ -5,6 +5,11 @@ search:
 
 # Class: UnitConversionConfiguration 
 
+
+_Configuration for converting a slot value from a source unit of measure to a target unit during transformation._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -49,14 +54,14 @@ URI: [linkmlmap:UnitConversionConfiguration](https://w3id.org/linkml/transformer
 
 | Name | Cardinality and Range | Description | Inheritance |
 | ---  | --- | --- | --- |
-| [target_unit](target_unit.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [target_unit_scheme](target_unit_scheme.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [source_unit](source_unit.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [source_unit_scheme](source_unit_scheme.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [source_unit_slot](source_unit_slot.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [source_magnitude_slot](source_magnitude_slot.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [target_unit_slot](target_unit_slot.md) | 0..1 <br/> [String](String.md) |  | direct |
-| [target_magnitude_slot](target_magnitude_slot.md) | 0..1 <br/> [String](String.md) |  | direct |
+| [target_unit](target_unit.md) | 0..1 <br/> [String](String.md) | The unit to convert the value into | direct |
+| [target_unit_scheme](target_unit_scheme.md) | 0..1 <br/> [String](String.md) | The unit scheme or system identifying target_unit (for example ucum) | direct |
+| [source_unit](source_unit.md) | 0..1 <br/> [String](String.md) | The unit the source value is expressed in | direct |
+| [source_unit_scheme](source_unit_scheme.md) | 0..1 <br/> [String](String.md) | The unit scheme or system identifying source_unit (for example ucum) | direct |
+| [source_unit_slot](source_unit_slot.md) | 0..1 <br/> [String](String.md) | For structured value-and-unit source input, the key within the source value t... | direct |
+| [source_magnitude_slot](source_magnitude_slot.md) | 0..1 <br/> [String](String.md) | For structured value-and-unit source input, the key within the source value t... | direct |
+| [target_unit_slot](target_unit_slot.md) | 0..1 <br/> [String](String.md) | When emitting structured output, the key to write the target unit into | direct |
+| [target_magnitude_slot](target_magnitude_slot.md) | 0..1 <br/> [String](String.md) | When emitting structured output, the key to write the converted magnitude int... | direct |
 | [none_if_non_numeric](none_if_non_numeric.md) | 0..1 <br/> [Boolean](Boolean.md) | If true, return None when the source value cannot be coerced to a numeric typ... | direct |
 
 
@@ -115,16 +120,21 @@ URI: [linkmlmap:UnitConversionConfiguration](https://w3id.org/linkml/transformer
 <details>
 ```yaml
 name: UnitConversionConfiguration
+description: Configuration for converting a slot value from a source unit of measure
+  to a target unit during transformation.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   target_unit:
     name: target_unit
+    description: The unit to convert the value into. If omitted, the source unit is
+      used unchanged.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - UnitConversionConfiguration
   target_unit_scheme:
     name: target_unit_scheme
+    description: The unit scheme or system identifying target_unit (for example ucum).
     examples:
     - value: ucum
     from_schema: https://w3id.org/linkml/transformer
@@ -134,12 +144,15 @@ attributes:
     range: string
   source_unit:
     name: source_unit
+    description: The unit the source value is expressed in. Cross-checked against
+      any unit declared on the source slot in the schema.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - UnitConversionConfiguration
   source_unit_scheme:
     name: source_unit_scheme
+    description: The unit scheme or system identifying source_unit (for example ucum).
     examples:
     - value: ucum
     from_schema: https://w3id.org/linkml/transformer
@@ -149,24 +162,32 @@ attributes:
     range: string
   source_unit_slot:
     name: source_unit_slot
+    description: For structured value-and-unit source input, the key within the source
+      value that holds the unit.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - UnitConversionConfiguration
   source_magnitude_slot:
     name: source_magnitude_slot
+    description: For structured value-and-unit source input, the key within the source
+      value that holds the numeric magnitude.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - UnitConversionConfiguration
   target_unit_slot:
     name: target_unit_slot
+    description: When emitting structured output, the key to write the target unit
+      into.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
     - UnitConversionConfiguration
   target_magnitude_slot:
     name: target_magnitude_slot
+    description: When emitting structured output, the key to write the converted magnitude
+      into. Its presence makes the result a structured value rather than a bare number.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     domain_of:
@@ -190,10 +211,14 @@ attributes:
 <details>
 ```yaml
 name: UnitConversionConfiguration
+description: Configuration for converting a slot value from a source unit of measure
+  to a target unit during transformation.
 from_schema: https://w3id.org/linkml/transformer
 attributes:
   target_unit:
     name: target_unit
+    description: The unit to convert the value into. If omitted, the source unit is
+      used unchanged.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration
@@ -201,6 +226,7 @@ attributes:
     - UnitConversionConfiguration
   target_unit_scheme:
     name: target_unit_scheme
+    description: The unit scheme or system identifying target_unit (for example ucum).
     examples:
     - value: ucum
     from_schema: https://w3id.org/linkml/transformer
@@ -211,6 +237,8 @@ attributes:
     range: string
   source_unit:
     name: source_unit
+    description: The unit the source value is expressed in. Cross-checked against
+      any unit declared on the source slot in the schema.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration
@@ -218,6 +246,7 @@ attributes:
     - UnitConversionConfiguration
   source_unit_scheme:
     name: source_unit_scheme
+    description: The unit scheme or system identifying source_unit (for example ucum).
     examples:
     - value: ucum
     from_schema: https://w3id.org/linkml/transformer
@@ -228,6 +257,8 @@ attributes:
     range: string
   source_unit_slot:
     name: source_unit_slot
+    description: For structured value-and-unit source input, the key within the source
+      value that holds the unit.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration
@@ -235,6 +266,8 @@ attributes:
     - UnitConversionConfiguration
   source_magnitude_slot:
     name: source_magnitude_slot
+    description: For structured value-and-unit source input, the key within the source
+      value that holds the numeric magnitude.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration
@@ -242,6 +275,8 @@ attributes:
     - UnitConversionConfiguration
   target_unit_slot:
     name: target_unit_slot
+    description: When emitting structured output, the key to write the target unit
+      into.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration
@@ -249,6 +284,8 @@ attributes:
     - UnitConversionConfiguration
   target_magnitude_slot:
     name: target_magnitude_slot
+    description: When emitting structured output, the key to write the converted magnitude
+      into. Its presence makes the result a structured value rather than a bare number.
     from_schema: https://w3id.org/linkml/transformer
     rank: 1000
     owner: UnitConversionConfiguration

--- a/docs/schema/add.md
+++ b/docs/schema/add.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: add 
 
+
+_Add new sub-elements that are not present in the source element. Currently under-specified and not yet implemented (see issue #245)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:add](https://w3id.org/linkml/transformer/add)
 <details>
 ```yaml
 name: add
+description: 'Add new sub-elements that are not present in the source element. Currently
+  under-specified and not yet implemented (see issue #245).'
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: CopyDirective

--- a/docs/schema/aggregation_operation.md
+++ b/docs/schema/aggregation_operation.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: aggregation_operation 
 
+
+_An aggregation operation that reduces multiple source values into this slot's value._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:aggregation_operation](https://w3id.org/linkml/transformer/aggre
 <details>
 ```yaml
 name: aggregation_operation
+description: An aggregation operation that reduces multiple source values into this
+  slot's value.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/cast_collection_as.md
+++ b/docs/schema/cast_collection_as.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: cast_collection_as 
 
+
+_Coerce the derived slot's collection form (for example single-valued, list, or dictionary)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:cast_collection_as](https://w3id.org/linkml/transformer/cast_col
 <details>
 ```yaml
 name: cast_collection_as
+description: Coerce the derived slot's collection form (for example single-valued,
+  list, or dictionary).
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/class_name.md
+++ b/docs/schema/class_name.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: class_name 
 
+
+_Name of the class that holds the back-reference (foreign key) slot._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,7 @@ URI: [linkmlmap:class_name](https://w3id.org/linkml/transformer/class_name)
 <details>
 ```yaml
 name: class_name
+description: Name of the class that holds the back-reference (foreign key) slot.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: Inverse

--- a/docs/schema/comments.md
+++ b/docs/schema/comments.md
@@ -33,7 +33,7 @@ URI: [rdfs:comment](http://www.w3.org/2000/01/rdf-schema#comment)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/copy_directives.md
+++ b/docs/schema/copy_directives.md
@@ -27,7 +27,7 @@ URI: [linkmlmap:copy_directives](https://w3id.org/linkml/transformer/copy_direct
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/datamodel.md
+++ b/docs/schema/datamodel.md
@@ -29,10 +29,10 @@ Name: linkml-map
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Person](Person.md) | An individual person who contributes to a mapping specification |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Software](Software.md) | A software tool or system used in creating mappings |
 | [AliasedClass](AliasedClass.md) | alias-class key value pairs for classes |
-| [Any](Any.md) |  |
+| [Any](Any.md) | A wildcard type that accepts any value |
 | [CopyDirective](CopyDirective.md) | Instructs a Schema Mapper in how to map to a target schema |
 | [Inverse](Inverse.md) | Used for back references in mapping to relational model |
-| [KeyVal](KeyVal.md) |  |
+| [KeyVal](KeyVal.md) | A generic key-value pair |
 | [Offset](Offset.md) | Configuration for calculating a value by applying an offset to a baseline val... |
 | [SchemaReference](SchemaReference.md) | A reference to a LinkML schema, with optional version and locator metadata |
 | [SpecificationComponent](SpecificationComponent.md) |  |
@@ -41,15 +41,15 @@ Name: linkml-map
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[ObjectDerivation](ObjectDerivation.md) | Deprecated |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PrefixDerivation](PrefixDerivation.md) |  |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[TransformationSpecification](TransformationSpecification.md) | A collection of mappings between source and target classes |
-| [StringificationConfiguration](StringificationConfiguration.md) |  |
+| [StringificationConfiguration](StringificationConfiguration.md) | Configuration for collapsing multiple values into a single delimited or seria... |
 | [TransformationOperation](TransformationOperation.md) |  |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AggregationOperation](AggregationOperation.md) |  |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GroupingOperation](GroupingOperation.md) |  |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PivotOperation](PivotOperation.md) |  |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[AggregationOperation](AggregationOperation.md) | An operation that reduces multiple input values to a single value using an ag... |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[GroupingOperation](GroupingOperation.md) | An operation that groups source rows prior to aggregation |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |
 
 
 
@@ -57,27 +57,27 @@ Name: linkml-map
 
 | Slot | Description |
 | --- | --- |
-| [add](add.md) |  |
+| [add](add.md) | Add new sub-elements that are not present in the source element |
 | [affiliation](affiliation.md) | Institutional affiliation of the person |
-| [aggregation_operation](aggregation_operation.md) |  |
+| [aggregation_operation](aggregation_operation.md) | An aggregation operation that reduces multiple source values into this slot's... |
 | [alias](alias.md) | name of the class to be aliased |
 | [author](author.md) | A list of authors of this transformation specification |
-| [cast_collection_as](cast_collection_as.md) |  |
+| [cast_collection_as](cast_collection_as.md) | Coerce the derived slot's collection form (for example single-valued, list, o... |
 | [class_derivations](class_derivations.md) | Instructions on how to derive a set of classes in the target schema from clas... |
-| [class_name](class_name.md) |  |
+| [class_name](class_name.md) | Name of the class that holds the back-reference (foreign key) slot |
 | [class_named](class_named.md) | local alias for the class |
 | [comments](comments.md) | A list of comments about this component |
 | [content_url](content_url.md) | Reference to the actual content of the mapping specification |
 | [copy_all](copy_all.md) | Copy all sub-elements of the Element being derived |
-| [copy_directives](copy_directives.md) |  |
+| [copy_directives](copy_directives.md) | Directives controlling which elements of the source schema are copied into th... |
 | [creator](creator.md) | A list of creators of this transformation specification |
-| [delimiter](delimiter.md) |  |
+| [delimiter](delimiter.md) | Delimiter used to join multiple values into a single string |
 | [derived_from](derived_from.md) | Deprecated |
 | [description](description.md) | description of the specification component |
-| [dictionary_key](dictionary_key.md) |  |
-| [direction](direction.md) |  |
+| [dictionary_key](dictionary_key.md) | When the derived value is a list of objects, the slot whose value is used as ... |
+| [direction](direction.md) | Whether to MELT (wide to long) or UNMELT (long to wide) |
 | [documentation](documentation.md) | URL or reference to documentation for the mapping specification |
-| [element_name](element_name.md) |  |
+| [element_name](element_name.md) | Name of the source element (class, slot, enum, etc |
 | [enum_derivations](enum_derivations.md) | Instructions on how to derive a set of enums in the target schema |
 | [exclude](exclude.md) | Remove certain sub-elements from the list of sub-elements to be copied |
 | [exclude_all](exclude_all.md) | Do not copy any of the sub-elements of the Element being derived |
@@ -90,68 +90,68 @@ Name: linkml-map
 | [id_slots](id_slots.md) | Slots that identify the entity (not pivoted) |
 | [implements](implements.md) | A reference to a specification that this component implements |
 | [include](include.md) | Add certain sub-elements to the list of sub-elements to be copied |
-| [invalid_value_handling](invalid_value_handling.md) |  |
+| [invalid_value_handling](invalid_value_handling.md) | How to handle values that cannot be interpreted as valid input to the aggrega... |
 | [inverse_of](inverse_of.md) | Used to specify a class-slot tuple that is the inverse of the derived/target ... |
-| [is_a](is_a.md) |  |
+| [is_a](is_a.md) | The parent element that the derived target element inherits from |
 | [join_on](join_on.md) | shorthand for source_key and lookup_key when both share the same column name |
 | [joins](joins.md) | Additional classes to be joined to derive instances of the target class |
-| [key](key.md) |  |
+| [key](key.md) | The key |
 | [license](license.md) | license under which this transformation specification is published |
 | [lookup_key](lookup_key.md) | column in the secondary (joined) table used as the join key |
 | [mapping_method](mapping_method.md) | The method used to create this mapping, e |
-| [mirror_source](mirror_source.md) |  |
-| [mixins](mixins.md) |  |
+| [mirror_source](mirror_source.md) | If true, pass the source value through unchanged instead of transforming it |
+| [mixins](mixins.md) | Mixin elements applied to the derived target element |
 | [name](name.md) | The name or identifier of the schema |
 | [none_if_non_numeric](none_if_non_numeric.md) | If true, return None when the source value cannot be coerced to a numeric typ... |
-| [null_handling](null_handling.md) |  |
+| [null_handling](null_handling.md) | How to handle null values encountered during aggregation |
 | [object_derivations](object_derivations.md) | Deprecated |
 | [offset](offset.md) | Configuration for calculating a value by applying an offset to a baseline val... |
 | [offset_field](offset_field.md) | Name of the field in the source object that contains the offset amount |
 | [offset_reverse](offset_reverse.md) | If true, subtract the offset from the baseline (baseline - offset) |
 | [offset_value](offset_value.md) | Multiplier applied to the offset field value |
-| [operator](operator.md) |  |
+| [operator](operator.md) | The aggregation function to apply (for example SUM, AVERAGE, COUNT) |
 | [orcid](orcid.md) | ORCID identifier for the person |
-| [over_slots](over_slots.md) |  |
+| [over_slots](over_slots.md) | The source slots whose values are combined into the stringified result |
 | [overrides](overrides.md) | overrides source schema slots |
 | [permissible_value_derivations](permissible_value_derivations.md) | Instructions on how to derive a set of PVs in the target schema |
 | [pivot_operation](pivot_operation.md) | Configuration for pivot (unmelt) operations at class level |
 | [populated_from](populated_from.md) | Source class to derive this target class from |
 | [prefixes](prefixes.md) | maps prefixes to URL expansions |
 | [publication_date](publication_date.md) | date of publication of this transformation specification |
-| [range](range.md) |  |
+| [range](range.md) | The range (value type) to assign to the derived target slot, overriding the r... |
 | [repository_url](repository_url.md) | URL to a code repository |
-| [reversed](reversed.md) |  |
+| [reversed](reversed.md) | If true, reverse the operation, splitting a delimited or serialized string ba... |
 | [reviewer](reviewer.md) | A list of reviewers of this transformation specification |
 | [ror_id](ror_id.md) | ROR (Research Organization Registry) identifier |
 | [schema_uri](schema_uri.md) | The URI/IRI identifier of the schema (matches the schema's `id`) |
 | [slot_derivations](slot_derivations.md) | Instructions on how to derive a set of top level slots in the target schema |
-| [slot_name](slot_name.md) |  |
+| [slot_name](slot_name.md) | Name of the slot on the referenced class that back-references the derived slo... |
 | [slot_name_template](slot_name_template.md) | Template for generating target slot names |
 | [source_file](source_file.md) | Optional file path or URL from which the schema can be loaded |
 | [source_key](source_key.md) | column in the primary (populated_from) table used as the join key |
-| [source_magnitude_slot](source_magnitude_slot.md) |  |
+| [source_magnitude_slot](source_magnitude_slot.md) | For structured value-and-unit source input, the key within the source value t... |
 | [source_schema](source_schema.md) | Reference to the schema that describes the source (input) objects |
 | [source_schema_patches](source_schema_patches.md) | Schema patches to apply to the source schema before transformation |
 | [source_slots](source_slots.md) | For MELT, the list of wide-format slots to melt |
-| [source_unit](source_unit.md) |  |
-| [source_unit_scheme](source_unit_scheme.md) |  |
-| [source_unit_slot](source_unit_slot.md) |  |
+| [source_unit](source_unit.md) | The unit the source value is expressed in |
+| [source_unit_scheme](source_unit_scheme.md) | The unit scheme or system identifying source_unit (for example ucum) |
+| [source_unit_slot](source_unit_slot.md) | For structured value-and-unit source input, the key within the source value t... |
 | [sources](sources.md) | Deprecated |
-| [stringification](stringification.md) |  |
-| [syntax](syntax.md) |  |
+| [stringification](stringification.md) | Configuration for combining multiple values into a single string value |
+| [syntax](syntax.md) | Serialization syntax used to stringify the values when no delimiter is given |
 | [target_definition](target_definition.md) | LinkML class definition object for this slot |
-| [target_magnitude_slot](target_magnitude_slot.md) |  |
+| [target_magnitude_slot](target_magnitude_slot.md) | When emitting structured output, the key to write the converted magnitude int... |
 | [target_schema](target_schema.md) | Reference to the schema that describes the target (output) objects |
-| [target_unit](target_unit.md) |  |
-| [target_unit_scheme](target_unit_scheme.md) |  |
-| [target_unit_slot](target_unit_slot.md) |  |
+| [target_unit](target_unit.md) | The unit to convert the value into |
+| [target_unit_scheme](target_unit_scheme.md) | The unit scheme or system identifying target_unit (for example ucum) |
+| [target_unit_slot](target_unit_slot.md) | When emitting structured output, the key to write the target unit into |
 | [title](title.md) | human readable title for this transformation specification |
 | [type](type.md) | Type of the agent |
-| [type_designator](type_designator.md) |  |
-| [unit_conversion](unit_conversion.md) |  |
+| [type_designator](type_designator.md) | True if this target slot designates the type (class) of the instance, analogo... |
+| [unit_conversion](unit_conversion.md) | Configuration for converting the source value's unit of measure when deriving... |
 | [unit_slot](unit_slot.md) | Optional slot containing unit information for {variable}_{unit} naming |
 | [unmelt_to_class](unmelt_to_class.md) | In an unmelt operation, attributes (which are values in the long/melted/EAV r... |
-| [unmelt_to_slots](unmelt_to_slots.md) |  |
+| [unmelt_to_slots](unmelt_to_slots.md) | For an unmelt operation, the target wide-format slots to populate from the lo... |
 | [url](url.md) | URL or web address of the organization |
 | [value](value.md) | A constant value to assign to the target slot |
 | [value_mappings](value_mappings.md) | A mapping table that is applied directly to mappings, in order of precedence |

--- a/docs/schema/datamodel.md
+++ b/docs/schema/datamodel.md
@@ -77,7 +77,7 @@ Name: linkml-map
 | [dictionary_key](dictionary_key.md) | When the derived value is a list of objects, the slot whose value is used as ... |
 | [direction](direction.md) | Whether to MELT (wide to long) or UNMELT (long to wide) |
 | [documentation](documentation.md) | URL or reference to documentation for the mapping specification |
-| [element_name](element_name.md) | Name of the source element (class, slot, enum, etc |
+| [element_name](element_name.md) | Name of the source element this directive applies to (a class, slot, enum, et... |
 | [enum_derivations](enum_derivations.md) | Instructions on how to derive a set of enums in the target schema |
 | [exclude](exclude.md) | Remove certain sub-elements from the list of sub-elements to be copied |
 | [exclude_all](exclude_all.md) | Do not copy any of the sub-elements of the Element being derived |

--- a/docs/schema/delimiter.md
+++ b/docs/schema/delimiter.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: delimiter 
 
+
+_Delimiter used to join multiple values into a single string._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:delimiter](https://w3id.org/linkml/transformer/delimiter)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [StringificationConfiguration](StringificationConfiguration.md) |  |  no  |
+| [StringificationConfiguration](StringificationConfiguration.md) | Configuration for collapsing multiple values into a single delimited or seria... |  no  |
 
 
 
@@ -95,6 +100,7 @@ URI: [linkmlmap:delimiter](https://w3id.org/linkml/transformer/delimiter)
 <details>
 ```yaml
 name: delimiter
+description: Delimiter used to join multiple values into a single string.
 examples:
 - value: ','
 - value: '|'

--- a/docs/schema/description.md
+++ b/docs/schema/description.md
@@ -33,7 +33,7 @@ URI: [dcterms:description](http://purl.org/dc/terms/description)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/dictionary_key.md
+++ b/docs/schema/dictionary_key.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: dictionary_key 
 
+
+_When the derived value is a list of objects, the slot whose value is used as the key to index them into a dictionary._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:dictionary_key](https://w3id.org/linkml/transformer/dictionary_k
 <details>
 ```yaml
 name: dictionary_key
+description: When the derived value is a list of objects, the slot whose value is
+  used as the key to index them into a dictionary.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/direction.md
+++ b/docs/schema/direction.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: direction 
 
+
+_Whether to MELT (wide to long) or UNMELT (long to wide)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:direction](https://w3id.org/linkml/transformer/direction)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 
@@ -87,6 +92,7 @@ URI: [linkmlmap:direction](https://w3id.org/linkml/transformer/direction)
 <details>
 ```yaml
 name: direction
+description: Whether to MELT (wide to long) or UNMELT (long to wide).
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: PivotOperation

--- a/docs/schema/element_name.md
+++ b/docs/schema/element_name.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: element_name 
 
+
+_Name of the source element (class, slot, enum, etc.) this directive applies to._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -88,6 +93,8 @@ URI: [linkmlmap:element_name](https://w3id.org/linkml/transformer/element_name)
 <details>
 ```yaml
 name: element_name
+description: Name of the source element (class, slot, enum, etc.) this directive applies
+  to.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 key: true

--- a/docs/schema/element_name.md
+++ b/docs/schema/element_name.md
@@ -6,7 +6,7 @@ search:
 # Slot: element_name 
 
 
-_Name of the source element (class, slot, enum, etc.) this directive applies to._
+_Name of the source element this directive applies to (a class, slot, enum, etc.)._
 
 
 
@@ -93,8 +93,8 @@ URI: [linkmlmap:element_name](https://w3id.org/linkml/transformer/element_name)
 <details>
 ```yaml
 name: element_name
-description: Name of the source element (class, slot, enum, etc.) this directive applies
-  to.
+description: Name of the source element this directive applies to (a class, slot,
+  enum, etc.).
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 key: true

--- a/docs/schema/expression_mappings.md
+++ b/docs/schema/expression_mappings.md
@@ -31,7 +31,7 @@ URI: [linkmlmap:expression_mappings](https://w3id.org/linkml/transformer/express
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/expression_to_expression_mappings.md
+++ b/docs/schema/expression_to_expression_mappings.md
@@ -31,7 +31,7 @@ URI: [linkmlmap:expression_to_expression_mappings](https://w3id.org/linkml/trans
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/expression_to_value_mappings.md
+++ b/docs/schema/expression_to_value_mappings.md
@@ -31,7 +31,7 @@ URI: [linkmlmap:expression_to_value_mappings](https://w3id.org/linkml/transforme
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/id_slots.md
+++ b/docs/schema/id_slots.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:id_slots](https://w3id.org/linkml/transformer/id_slots)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/implements.md
+++ b/docs/schema/implements.md
@@ -33,7 +33,7 @@ URI: [linkmlmap:implements](https://w3id.org/linkml/transformer/implements)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/invalid_value_handling.md
+++ b/docs/schema/invalid_value_handling.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: invalid_value_handling 
 
+
+_How to handle values that cannot be interpreted as valid input to the aggregation._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:invalid_value_handling](https://w3id.org/linkml/transformer/inva
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AggregationOperation](AggregationOperation.md) |  |  no  |
+| [AggregationOperation](AggregationOperation.md) | An operation that reduces multiple input values to a single value using an ag... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:invalid_value_handling](https://w3id.org/linkml/transformer/inva
 <details>
 ```yaml
 name: invalid_value_handling
+description: How to handle values that cannot be interpreted as valid input to the
+  aggregation.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: AggregationOperation

--- a/docs/schema/is_a.md
+++ b/docs/schema/is_a.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: is_a 
 
+
+_The parent element that the derived target element inherits from._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -26,7 +31,7 @@ URI: [linkml:is_a](https://w3id.org/linkml/is_a)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 
@@ -93,6 +98,7 @@ URI: [linkml:is_a](https://w3id.org/linkml/is_a)
 <details>
 ```yaml
 name: is_a
+description: The parent element that the derived target element inherits from.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 slot_uri: linkml:is_a

--- a/docs/schema/key.md
+++ b/docs/schema/key.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: key 
 
+
+_The key._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:key](https://w3id.org/linkml/transformer/key)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [KeyVal](KeyVal.md) |  |  no  |
+| [KeyVal](KeyVal.md) | A generic key-value pair |  no  |
 
 
 
@@ -88,6 +93,7 @@ URI: [linkmlmap:key](https://w3id.org/linkml/transformer/key)
 <details>
 ```yaml
 name: key
+description: The key.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 key: true

--- a/docs/schema/mirror_source.md
+++ b/docs/schema/mirror_source.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: mirror_source 
 
+
+_If true, pass the source value through unchanged instead of transforming it._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -26,7 +31,7 @@ URI: [linkmlmap:mirror_source](https://w3id.org/linkml/transformer/mirror_source
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 
@@ -92,6 +97,8 @@ URI: [linkmlmap:mirror_source](https://w3id.org/linkml/transformer/mirror_source
 <details>
 ```yaml
 name: mirror_source
+description: If true, pass the source value through unchanged instead of transforming
+  it.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: ElementDerivation

--- a/docs/schema/mixins.md
+++ b/docs/schema/mixins.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: mixins 
 
+
+_Mixin elements applied to the derived target element._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -26,7 +31,7 @@ URI: [linkml:mixins](https://w3id.org/linkml/mixins)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 
@@ -94,6 +99,7 @@ URI: [linkml:mixins](https://w3id.org/linkml/mixins)
 <details>
 ```yaml
 name: mixins
+description: Mixin elements applied to the derived target element.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 slot_uri: linkml:mixins

--- a/docs/schema/name.md
+++ b/docs/schema/name.md
@@ -27,7 +27,7 @@ URI: [linkmlmap:name](https://w3id.org/linkml/transformer/name)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 | [Agent](Agent.md) | An entity that can create or contribute to a digital object, such as an autho... |  no  |
 | [Person](Person.md) | An individual person who contributes to a mapping specification |  no  |
 | [Organization](Organization.md) | An organization or institution that contributes to a mapping specification |  no  |

--- a/docs/schema/none_if_non_numeric.md
+++ b/docs/schema/none_if_non_numeric.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:none_if_non_numeric](https://w3id.org/linkml/transformer/none_if
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 

--- a/docs/schema/null_handling.md
+++ b/docs/schema/null_handling.md
@@ -20,8 +20,8 @@ URI: [linkmlmap:null_handling](https://w3id.org/linkml/transformer/null_handling
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AggregationOperation](AggregationOperation.md) |  |  no  |
-| [GroupingOperation](GroupingOperation.md) |  |  no  |
+| [AggregationOperation](AggregationOperation.md) | An operation that reduces multiple input values to a single value using an ag... |  no  |
+| [GroupingOperation](GroupingOperation.md) | An operation that groups source rows prior to aggregation |  no  |
 
 
 

--- a/docs/schema/operator.md
+++ b/docs/schema/operator.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: operator 
 
+
+_The aggregation function to apply (for example SUM, AVERAGE, COUNT)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:operator](https://w3id.org/linkml/transformer/operator)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [AggregationOperation](AggregationOperation.md) |  |  no  |
+| [AggregationOperation](AggregationOperation.md) | An operation that reduces multiple input values to a single value using an ag... |  no  |
 
 
 
@@ -87,6 +92,7 @@ URI: [linkmlmap:operator](https://w3id.org/linkml/transformer/operator)
 <details>
 ```yaml
 name: operator
+description: The aggregation function to apply (for example SUM, AVERAGE, COUNT).
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: AggregationOperation

--- a/docs/schema/over_slots.md
+++ b/docs/schema/over_slots.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: over_slots 
 
+
+_The source slots whose values are combined into the stringified result._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:over_slots](https://w3id.org/linkml/transformer/over_slots)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [StringificationConfiguration](StringificationConfiguration.md) |  |  no  |
+| [StringificationConfiguration](StringificationConfiguration.md) | Configuration for collapsing multiple values into a single delimited or seria... |  no  |
 
 
 
@@ -87,6 +92,7 @@ URI: [linkmlmap:over_slots](https://w3id.org/linkml/transformer/over_slots)
 <details>
 ```yaml
 name: over_slots
+description: The source slots whose values are combined into the stringified result.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: StringificationConfiguration

--- a/docs/schema/overrides.md
+++ b/docs/schema/overrides.md
@@ -31,7 +31,7 @@ URI: [linkmlmap:overrides](https://w3id.org/linkml/transformer/overrides)
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/range.md
+++ b/docs/schema/range.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: range 
 
+
+_The range (value type) to assign to the derived target slot, overriding the range inferred from the source._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -87,6 +92,8 @@ URI: [linkml:range](https://w3id.org/linkml/range)
 <details>
 ```yaml
 name: range
+description: The range (value type) to assign to the derived target slot, overriding
+  the range inferred from the source.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 slot_uri: linkml:range

--- a/docs/schema/reversed.md
+++ b/docs/schema/reversed.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: reversed 
 
+
+_If true, reverse the operation, splitting a delimited or serialized string back into multiple values._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:reversed](https://w3id.org/linkml/transformer/reversed)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [StringificationConfiguration](StringificationConfiguration.md) |  |  no  |
+| [StringificationConfiguration](StringificationConfiguration.md) | Configuration for collapsing multiple values into a single delimited or seria... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:reversed](https://w3id.org/linkml/transformer/reversed)
 <details>
 ```yaml
 name: reversed
+description: If true, reverse the operation, splitting a delimited or serialized string
+  back into multiple values.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: StringificationConfiguration

--- a/docs/schema/slot_name.md
+++ b/docs/schema/slot_name.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: slot_name 
 
+
+_Name of the slot on the referenced class that back-references the derived slot._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:slot_name](https://w3id.org/linkml/transformer/slot_name)
 <details>
 ```yaml
 name: slot_name
+description: Name of the slot on the referenced class that back-references the derived
+  slot.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: Inverse

--- a/docs/schema/slot_name_template.md
+++ b/docs/schema/slot_name_template.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:slot_name_template](https://w3id.org/linkml/transformer/slot_nam
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/source_magnitude_slot.md
+++ b/docs/schema/source_magnitude_slot.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: source_magnitude_slot 
 
+
+_For structured value-and-unit source input, the key within the source value that holds the numeric magnitude._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:source_magnitude_slot](https://w3id.org/linkml/transformer/sourc
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:source_magnitude_slot](https://w3id.org/linkml/transformer/sourc
 <details>
 ```yaml
 name: source_magnitude_slot
+description: For structured value-and-unit source input, the key within the source
+  value that holds the numeric magnitude.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/source_slots.md
+++ b/docs/schema/source_slots.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:source_slots](https://w3id.org/linkml/transformer/source_slots)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/source_unit.md
+++ b/docs/schema/source_unit.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: source_unit 
 
+
+_The unit the source value is expressed in. Cross-checked against any unit declared on the source slot in the schema._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:source_unit](https://w3id.org/linkml/transformer/source_unit)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:source_unit](https://w3id.org/linkml/transformer/source_unit)
 <details>
 ```yaml
 name: source_unit
+description: The unit the source value is expressed in. Cross-checked against any
+  unit declared on the source slot in the schema.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/source_unit_scheme.md
+++ b/docs/schema/source_unit_scheme.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: source_unit_scheme 
 
+
+_The unit scheme or system identifying source_unit (for example ucum)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:source_unit_scheme](https://w3id.org/linkml/transformer/source_u
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -93,6 +98,7 @@ URI: [linkmlmap:source_unit_scheme](https://w3id.org/linkml/transformer/source_u
 <details>
 ```yaml
 name: source_unit_scheme
+description: The unit scheme or system identifying source_unit (for example ucum).
 examples:
 - value: ucum
 from_schema: https://w3id.org/linkml/transformer

--- a/docs/schema/source_unit_slot.md
+++ b/docs/schema/source_unit_slot.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: source_unit_slot 
 
+
+_For structured value-and-unit source input, the key within the source value that holds the unit._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:source_unit_slot](https://w3id.org/linkml/transformer/source_uni
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:source_unit_slot](https://w3id.org/linkml/transformer/source_uni
 <details>
 ```yaml
 name: source_unit_slot
+description: For structured value-and-unit source input, the key within the source
+  value that holds the unit.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/stringification.md
+++ b/docs/schema/stringification.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: stringification 
 
+
+_Configuration for combining multiple values into a single string value._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,7 @@ URI: [linkmlmap:stringification](https://w3id.org/linkml/transformer/stringifica
 <details>
 ```yaml
 name: stringification
+description: Configuration for combining multiple values into a single string value.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/syntax.md
+++ b/docs/schema/syntax.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: syntax 
 
+
+_Serialization syntax used to stringify the values when no delimiter is given._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:syntax](https://w3id.org/linkml/transformer/syntax)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [StringificationConfiguration](StringificationConfiguration.md) |  |  no  |
+| [StringificationConfiguration](StringificationConfiguration.md) | Configuration for collapsing multiple values into a single delimited or seria... |  no  |
 
 
 
@@ -94,6 +99,8 @@ URI: [linkmlmap:syntax](https://w3id.org/linkml/transformer/syntax)
 <details>
 ```yaml
 name: syntax
+description: Serialization syntax used to stringify the values when no delimiter is
+  given.
 examples:
 - value: json
 - value: yaml

--- a/docs/schema/target_magnitude_slot.md
+++ b/docs/schema/target_magnitude_slot.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: target_magnitude_slot 
 
+
+_When emitting structured output, the key to write the converted magnitude into. Its presence makes the result a structured value rather than a bare number._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:target_magnitude_slot](https://w3id.org/linkml/transformer/targe
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:target_magnitude_slot](https://w3id.org/linkml/transformer/targe
 <details>
 ```yaml
 name: target_magnitude_slot
+description: When emitting structured output, the key to write the converted magnitude
+  into. Its presence makes the result a structured value rather than a bare number.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/target_unit.md
+++ b/docs/schema/target_unit.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: target_unit 
 
+
+_The unit to convert the value into. If omitted, the source unit is used unchanged._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:target_unit](https://w3id.org/linkml/transformer/target_unit)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:target_unit](https://w3id.org/linkml/transformer/target_unit)
 <details>
 ```yaml
 name: target_unit
+description: The unit to convert the value into. If omitted, the source unit is used
+  unchanged.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/target_unit_scheme.md
+++ b/docs/schema/target_unit_scheme.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: target_unit_scheme 
 
+
+_The unit scheme or system identifying target_unit (for example ucum)._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:target_unit_scheme](https://w3id.org/linkml/transformer/target_u
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -93,6 +98,7 @@ URI: [linkmlmap:target_unit_scheme](https://w3id.org/linkml/transformer/target_u
 <details>
 ```yaml
 name: target_unit_scheme
+description: The unit scheme or system identifying target_unit (for example ucum).
 examples:
 - value: ucum
 from_schema: https://w3id.org/linkml/transformer

--- a/docs/schema/target_unit_slot.md
+++ b/docs/schema/target_unit_slot.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: target_unit_slot 
 
+
+_When emitting structured output, the key to write the target unit into._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:target_unit_slot](https://w3id.org/linkml/transformer/target_uni
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [UnitConversionConfiguration](UnitConversionConfiguration.md) |  |  no  |
+| [UnitConversionConfiguration](UnitConversionConfiguration.md) | Configuration for converting a slot value from a source unit of measure to a ... |  no  |
 
 
 
@@ -86,6 +91,7 @@ URI: [linkmlmap:target_unit_slot](https://w3id.org/linkml/transformer/target_uni
 <details>
 ```yaml
 name: target_unit_slot
+description: When emitting structured output, the key to write the target unit into.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: UnitConversionConfiguration

--- a/docs/schema/type_designator.md
+++ b/docs/schema/type_designator.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: type_designator 
 
+
+_True if this target slot designates the type (class) of the instance, analogous to LinkML's designates_type._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:type_designator](https://w3id.org/linkml/transformer/type_design
 <details>
 ```yaml
 name: type_designator
+description: True if this target slot designates the type (class) of the instance,
+  analogous to LinkML's designates_type.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/unit_conversion.md
+++ b/docs/schema/unit_conversion.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: unit_conversion 
 
+
+_Configuration for converting the source value's unit of measure when deriving this slot._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -86,6 +91,8 @@ URI: [linkmlmap:unit_conversion](https://w3id.org/linkml/transformer/unit_conver
 <details>
 ```yaml
 name: unit_conversion
+description: Configuration for converting the source value's unit of measure when
+  deriving this slot.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: SlotDerivation

--- a/docs/schema/unit_slot.md
+++ b/docs/schema/unit_slot.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:unit_slot](https://w3id.org/linkml/transformer/unit_slot)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/unmelt_to_class.md
+++ b/docs/schema/unmelt_to_class.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:unmelt_to_class](https://w3id.org/linkml/transformer/unmelt_to_c
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/unmelt_to_slots.md
+++ b/docs/schema/unmelt_to_slots.md
@@ -5,6 +5,11 @@ search:
 
 # Slot: unmelt_to_slots 
 
+
+_For an unmelt operation, the target wide-format slots to populate from the long/EAV rows._
+
+
+
 <div data-search-exclude markdown="1">
 
 
@@ -20,7 +25,7 @@ URI: [linkmlmap:unmelt_to_slots](https://w3id.org/linkml/transformer/unmelt_to_s
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 
@@ -87,6 +92,8 @@ URI: [linkmlmap:unmelt_to_slots](https://w3id.org/linkml/transformer/unmelt_to_s
 <details>
 ```yaml
 name: unmelt_to_slots
+description: For an unmelt operation, the target wide-format slots to populate from
+  the long/EAV rows.
 from_schema: https://w3id.org/linkml/transformer
 rank: 1000
 owner: PivotOperation

--- a/docs/schema/value.md
+++ b/docs/schema/value.md
@@ -21,7 +21,7 @@ URI: [linkmlmap:value](https://w3id.org/linkml/transformer/value)
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
-| [KeyVal](KeyVal.md) |  |  no  |
+| [KeyVal](KeyVal.md) | A generic key-value pair |  no  |
 
 
 

--- a/docs/schema/value_mappings.md
+++ b/docs/schema/value_mappings.md
@@ -31,7 +31,7 @@ URI: [linkmlmap:value_mappings](https://w3id.org/linkml/transformer/value_mappin
 | [SlotDerivation](SlotDerivation.md) | A specification of how to derive the value of a target slot from a source slo... |  no  |
 | [EnumDerivation](EnumDerivation.md) | A specification of how to derive the value of a target enum from a source enu... |  no  |
 | [PermissibleValueDerivation](PermissibleValueDerivation.md) | A specification of how to derive the value of a PV from a source enum |  no  |
-| [PrefixDerivation](PrefixDerivation.md) |  |  no  |
+| [PrefixDerivation](PrefixDerivation.md) | A specification of how to derive a target prefix declaration |  no  |
 
 
 

--- a/docs/schema/value_slot.md
+++ b/docs/schema/value_slot.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:value_slot](https://w3id.org/linkml/transformer/value_slot)
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/docs/schema/variable_slot.md
+++ b/docs/schema/variable_slot.md
@@ -25,7 +25,7 @@ URI: [linkmlmap:variable_slot](https://w3id.org/linkml/transformer/variable_slot
 
 | Name | Description | Modifies Slot |
 | --- | --- | --- |
-| [PivotOperation](PivotOperation.md) |  |  no  |
+| [PivotOperation](PivotOperation.md) | An operation that reshapes data between wide and long (EAV) representations, ... |  no  |
 
 
 

--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -179,7 +179,7 @@ class TransformationSpecification(SpecificationComponent):
     version: Optional[str] = Field(default=None, description="""version of this transformation specification""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'SchemaReference', 'Software'],
          'slot_uri': 'schema:version'} })
     prefixes: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""maps prefixes to URL expansions""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification'], 'slot_uri': 'sh:declare'} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which elements of the source schema are copied into the target schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     source_schema: Optional[SchemaReference] = Field(default=None, description="""Reference to the schema that describes the source (input) objects.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     target_schema: Optional[SchemaReference] = Field(default=None, description="""Reference to the schema that describes the target (output) objects.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
     source_schema_patches: Optional[Any] = Field(default=None, description="""Schema patches to apply to the source schema before transformation. Useful for adding foreign key relationships to auto-generated schemas. Uses LinkML schema YAML structure (classes, slots, attributes, etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification']} })
@@ -252,17 +252,17 @@ class ElementDerivation(SpecificationComponent):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
@@ -289,7 +289,7 @@ class ClassDerivation(ElementDerivation):
     joins: Optional[dict[str, AliasedClass]] = Field(default_factory=dict, description="""Additional classes to be joined to derive instances of the target class""", json_schema_extra = { "linkml_meta": {'comments': ['supports cross-table lookups via source_key/lookup_key or the '
                       'join_on field'],
          'domain_of': ['ClassDerivation']} })
-    slot_derivations: Optional[dict[str, SlotDerivation]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ClassDerivation']} })
+    slot_derivations: Optional[dict[str, SlotDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive the slots of this target class from source data.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ClassDerivation']} })
     target_definition: Optional[Any] = Field(default=None, description="""LinkML class definition object for this slot.""", json_schema_extra = { "linkml_meta": {'comments': ['currently defined as Any to avoid coupling with metamodel'],
          'domain_of': ['ClassDerivation', 'SlotDerivation']} })
     pivot_operation: Optional[PivotOperation] = Field(default=None, description="""Configuration for pivot (unmelt) operations at class level""", json_schema_extra = { "linkml_meta": {'domain_of': ['ClassDerivation', 'SlotDerivation']} })
@@ -300,17 +300,17 @@ class ClassDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
@@ -332,20 +332,20 @@ class ObjectDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    class_derivations: Optional[dict[str, ClassDerivation]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification',
+    class_derivations: Optional[dict[str, ClassDerivation]] = Field(default_factory=dict, description="""Class derivations used to construct nested instances for this (deprecated) object derivation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification',
                        'ObjectDerivation',
                        'SlotDerivation']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
@@ -403,32 +403,32 @@ class SlotDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
     value: Optional[Any] = Field(default=None, description="""A constant value to assign to the target slot.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation', 'KeyVal']} })
-    range: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation'], 'slot_uri': 'linkml:range'} })
-    unit_conversion: Optional[UnitConversionConfiguration] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    range: Optional[str] = Field(default=None, description="""The range (value type) to assign to the derived target slot, overriding the range inferred from the source.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation'], 'slot_uri': 'linkml:range'} })
+    unit_conversion: Optional[UnitConversionConfiguration] = Field(default=None, description="""Configuration for converting the source value's unit of measure when deriving this slot.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
     inverse_of: Optional[Inverse] = Field(default=None, description="""Used to specify a class-slot tuple that is the inverse of the derived/target slot. This is used primarily for mapping to relational databases or formalisms that do not allow multiple values. The class representing the repeated element has a foreign key slot inserted in that 'back references' the original multivalued slot.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
     hide: Optional[bool] = Field(default=None, description="""True if this is suppressed""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation',
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
-    type_designator: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    type_designator: Optional[bool] = Field(default=None, description="""True if this target slot designates the type (class) of the instance, analogous to LinkML's designates_type.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
     target_definition: Optional[Any] = Field(default=None, description="""LinkML definition object for this slot.""", json_schema_extra = { "linkml_meta": {'comments': ['currently defined as Any to avoid coupling with metamodel'],
          'domain_of': ['ClassDerivation', 'SlotDerivation']} })
-    cast_collection_as: Optional[CollectionType] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
-    dictionary_key: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
-    stringification: Optional[StringificationConfiguration] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
-    aggregation_operation: Optional[AggregationOperation] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    cast_collection_as: Optional[CollectionType] = Field(default=None, description="""Coerce the derived slot's collection form (for example single-valued, list, or dictionary).""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    dictionary_key: Optional[str] = Field(default=None, description="""When the derived value is a list of objects, the slot whose value is used as the key to index them into a dictionary.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    stringification: Optional[StringificationConfiguration] = Field(default=None, description="""Configuration for combining multiple values into a single string value.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
+    aggregation_operation: Optional[AggregationOperation] = Field(default=None, description="""An aggregation operation that reduces multiple source values into this slot's value.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
     pivot_operation: Optional[PivotOperation] = Field(default=None, description="""Configuration for pivot (melt) operations producing this slot""", json_schema_extra = { "linkml_meta": {'domain_of': ['ClassDerivation', 'SlotDerivation']} })
     offset: Optional[Offset] = Field(default=None, description="""Configuration for calculating a value by applying an offset to a baseline value. The baseline value comes from the slot's populated_from field. This is commonly used for longitudinal data where measurements are recorded relative to a baseline. For example, calculating age_at_visit from age + (days * 1/365).""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
@@ -466,17 +466,17 @@ class EnumDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
     permissible_value_derivations: Optional[dict[str, PermissibleValueDerivation]] = Field(default_factory=dict, description="""Instructions on how to derive a set of PVs in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['EnumDerivation']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
@@ -497,7 +497,7 @@ class PermissibleValueDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    expr: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation',
+    expr: Optional[str] = Field(default=None, description="""An expression evaluated on the source object to derive this permissible value. Should be specified using the LinkML expression language.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation',
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
     populated_from: Optional[str] = Field(default=None, description="""Source permissible value that maps to this target permissible value.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ClassDerivation',
@@ -512,26 +512,29 @@ class PermissibleValueDerivation(ElementDerivation):
                        'SlotDerivation',
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
-    hide: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation',
+    hide: Optional[bool] = Field(default=None, description="""True if this is suppressed""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation',
                        'EnumDerivation',
                        'PermissibleValueDerivation']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
 
 
 class PrefixDerivation(ElementDerivation):
+    """
+    A specification of how to derive a target prefix declaration. Currently a placeholder with no additional fields.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
     name: str = Field(default=..., description="""Name of the element in the target schema""", json_schema_extra = { "linkml_meta": {'domain_of': ['SchemaReference',
@@ -541,33 +544,36 @@ class PrefixDerivation(ElementDerivation):
                        'EnumDerivation',
                        'PermissibleValueDerivation',
                        'Agent']} })
-    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
+    copy_directives: Optional[dict[str, CopyDirective]] = Field(default_factory=dict, description="""Directives controlling which sub-elements of the source element are copied into the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['TransformationSpecification', 'ElementDerivation']} })
     overrides: Optional[Any] = Field(default=None, description="""overrides source schema slots""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
-    is_a: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
-    mixins: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
+    is_a: Optional[str] = Field(default=None, description="""The parent element that the derived target element inherits from.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:is_a'} })
+    mixins: Optional[list[str]] = Field(default_factory=list, description="""Mixin elements applied to the derived target element.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation'], 'slot_uri': 'linkml:mixins'} })
     value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table that is applied directly to mappings, in order of precedence. Keys should always be quoted in YAML to prevent type coercion — unquoted true/false become booleans and bare numbers become integers, which will not match the stringified source value used for lookup.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table where the values are expressions evaluated against source bindings. Looked up by the same key as value_mappings (the stringified source value). Keys should always be quoted (see value_mappings). If both value_mappings and expression_mappings are present, value_mappings takes precedence for keys that appear in both.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_value_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys are boolean expressions and the values are literal results. On enum derivations, used for scalar binning: each key is evaluated with value() bound to the incoming value, and the first truthy key's value is returned as the target permissible value. See issue #99.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     expression_to_expression_mappings: Optional[dict[str, KeyVal]] = Field(default_factory=dict, description="""A mapping table in which the keys and values are expressions""", json_schema_extra = { "linkml_meta": {'deprecated': 'Deprecated: use case() with and/or operators instead (#127). '
                        'Will be removed before 1.0.',
          'domain_of': ['ElementDerivation']} })
-    mirror_source: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
+    mirror_source: Optional[bool] = Field(default=None, description="""If true, pass the source value through unchanged instead of transforming it.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ElementDerivation']} })
     description: Optional[str] = Field(default=None, description="""description of the specification component""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'dcterms:description'} })
     implements: Optional[list[str]] = Field(default_factory=list, description="""A reference to a specification that this component implements.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent']} })
     comments: Optional[list[str]] = Field(default_factory=list, description="""A list of comments about this component. Comments are free text, and may be used to provide additional information about the component, including instructions for its use.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SpecificationComponent'], 'slot_uri': 'rdfs:comment'} })
 
 
 class UnitConversionConfiguration(ConfiguredBaseModel):
+    """
+    Configuration for converting a slot value from a source unit of measure to a target unit during transformation.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    target_unit: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
-    target_unit_scheme: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration'], 'examples': [{'value': 'ucum'}]} })
-    source_unit: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
-    source_unit_scheme: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration'], 'examples': [{'value': 'ucum'}]} })
-    source_unit_slot: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
-    source_magnitude_slot: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
-    target_unit_slot: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
-    target_magnitude_slot: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    target_unit: Optional[str] = Field(default=None, description="""The unit to convert the value into. If omitted, the source unit is used unchanged.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    target_unit_scheme: Optional[str] = Field(default=None, description="""The unit scheme or system identifying target_unit (for example ucum).""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration'], 'examples': [{'value': 'ucum'}]} })
+    source_unit: Optional[str] = Field(default=None, description="""The unit the source value is expressed in. Cross-checked against any unit declared on the source slot in the schema.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    source_unit_scheme: Optional[str] = Field(default=None, description="""The unit scheme or system identifying source_unit (for example ucum).""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration'], 'examples': [{'value': 'ucum'}]} })
+    source_unit_slot: Optional[str] = Field(default=None, description="""For structured value-and-unit source input, the key within the source value that holds the unit.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    source_magnitude_slot: Optional[str] = Field(default=None, description="""For structured value-and-unit source input, the key within the source value that holds the numeric magnitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    target_unit_slot: Optional[str] = Field(default=None, description="""When emitting structured output, the key to write the target unit into.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
+    target_magnitude_slot: Optional[str] = Field(default=None, description="""When emitting structured output, the key to write the converted magnitude into. Its presence makes the result a structured value rather than a bare number.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
     none_if_non_numeric: Optional[bool] = Field(default=None, description="""If true, return None when the source value cannot be coerced to a numeric type instead of raising an error. This is an explicit opt-in for columns that contain non-numeric coded values (e.g. 'A', 'M') mixed with numeric data.""", json_schema_extra = { "linkml_meta": {'domain_of': ['UnitConversionConfiguration']} })
 
 
@@ -584,13 +590,16 @@ class Offset(ConfiguredBaseModel):
 
 
 class StringificationConfiguration(ConfiguredBaseModel):
+    """
+    Configuration for collapsing multiple values into a single delimited or serialized string value.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    delimiter: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration'],
+    delimiter: Optional[str] = Field(default=None, description="""Delimiter used to join multiple values into a single string.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration'],
          'examples': [{'value': ','}, {'value': '|'}, {'value': ';'}]} })
-    reversed: Optional[bool] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration']} })
-    over_slots: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration']} })
-    syntax: Optional[SerializationSyntaxType] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration'],
+    reversed: Optional[bool] = Field(default=None, description="""If true, reverse the operation, splitting a delimited or serialized string back into multiple values.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration']} })
+    over_slots: Optional[list[str]] = Field(default_factory=list, description="""The source slots whose values are combined into the stringified result.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration']} })
+    syntax: Optional[SerializationSyntaxType] = Field(default=None, description="""Serialization syntax used to stringify the values when no delimiter is given.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StringificationConfiguration'],
          'examples': [{'value': 'json'}, {'value': 'yaml'}]} })
 
 
@@ -601,8 +610,8 @@ class Inverse(ConfiguredBaseModel):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['backref', 'back_references'],
          'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    slot_name: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Inverse']} })
-    class_name: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Inverse']} })
+    slot_name: Optional[str] = Field(default=None, description="""Name of the slot on the referenced class that back-references the derived slot.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Inverse']} })
+    class_name: Optional[str] = Field(default=None, description="""Name of the class that holds the back-reference (foreign key) slot.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Inverse']} })
 
 
 class TransformationOperation(ConfiguredBaseModel):
@@ -612,24 +621,33 @@ class TransformationOperation(ConfiguredBaseModel):
 
 
 class AggregationOperation(TransformationOperation):
+    """
+    An operation that reduces multiple input values to a single value using an aggregation function such as sum, average, or count.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    operator: AggregationType = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation']} })
-    null_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation', 'GroupingOperation']} })
-    invalid_value_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation']} })
+    operator: AggregationType = Field(default=..., description="""The aggregation function to apply (for example SUM, AVERAGE, COUNT).""", json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation']} })
+    null_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, description="""How to handle null values encountered during aggregation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation', 'GroupingOperation']} })
+    invalid_value_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, description="""How to handle values that cannot be interpreted as valid input to the aggregation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation']} })
 
 
 class GroupingOperation(TransformationOperation):
+    """
+    An operation that groups source rows prior to aggregation.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    null_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation', 'GroupingOperation']} })
+    null_handling: Optional[InvalidValueHandlingStrategy] = Field(default=None, description="""How to handle null values when grouping.""", json_schema_extra = { "linkml_meta": {'domain_of': ['AggregationOperation', 'GroupingOperation']} })
 
 
 class PivotOperation(TransformationOperation):
+    """
+    An operation that reshapes data between wide and long (EAV) representations, i.e. melt (wide to long) and unmelt (long to wide).
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'aliases': ['melt/unmelt', 'reification/dereification'],
          'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    direction: PivotDirectionType = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
+    direction: PivotDirectionType = Field(default=..., description="""Whether to MELT (wide to long) or UNMELT (long to wide).""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
     variable_slot: Optional[str] = Field(default="variable", description="""Slot to use for the variable column in the melted/long representation. In EAV this is the name of the 'A' variable""", json_schema_extra = { "linkml_meta": {'aliases': ['var_name'],
          'domain_of': ['PivotOperation'],
          'ifabsent': 'string(variable)'} })
@@ -637,7 +655,7 @@ class PivotOperation(TransformationOperation):
          'domain_of': ['PivotOperation'],
          'ifabsent': 'string(value)'} })
     unmelt_to_class: Optional[str] = Field(default=None, description="""In an unmelt operation, attributes (which are values in the long/melted/EAV representation) must conform to valid attributes in this class""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
-    unmelt_to_slots: Optional[list[str]] = Field(default_factory=list, json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
+    unmelt_to_slots: Optional[list[str]] = Field(default_factory=list, description="""For an unmelt operation, the target wide-format slots to populate from the long/EAV rows.""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
     unit_slot: Optional[str] = Field(default=None, description="""Optional slot containing unit information for {variable}_{unit} naming""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
     slot_name_template: Optional[str] = Field(default="{variable}", description="""Template for generating target slot names. Supports {variable} and {unit}.""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation'], 'ifabsent': 'string({variable})'} })
     source_slots: Optional[list[str]] = Field(default_factory=list, description="""For MELT, the list of wide-format slots to melt""", json_schema_extra = { "linkml_meta": {'domain_of': ['PivotOperation']} })
@@ -645,10 +663,13 @@ class PivotOperation(TransformationOperation):
 
 
 class KeyVal(ConfiguredBaseModel):
+    """
+    A generic key-value pair.
+    """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer'})
 
-    key: str = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['KeyVal']} })
-    value: Optional[Any] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation', 'KeyVal']} })
+    key: str = Field(default=..., description="""The key.""", json_schema_extra = { "linkml_meta": {'domain_of': ['KeyVal']} })
+    value: Optional[Any] = Field(default=None, description="""The value associated with the key.""", json_schema_extra = { "linkml_meta": {'domain_of': ['SlotDerivation', 'KeyVal']} })
 
 
 class Agent(ConfiguredBaseModel):
@@ -739,14 +760,14 @@ class CopyDirective(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer', 'status': 'testing'})
 
-    element_name: str = Field(default=..., json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
+    element_name: str = Field(default=..., description="""Name of the source element (class, slot, enum, etc.) this directive applies to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     copy_all: Optional[bool] = Field(default=None, description="""Copy all sub-elements of the Element being derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     exclude_all: Optional[bool] = Field(default=None, description="""Do not copy any of the sub-elements of the Element being derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     exclude: Optional[Any] = Field(default=None, description="""Remove certain sub-elements from the list of sub-elements to be copied.
 As of now there it is under-specified, how to specify the sub-elements to exclude. One possible implementation would be a list where all element types can be mixed, since there might not be name conflicts across element types.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     include: Optional[Any] = Field(default=None, description="""Add certain sub-elements to the list of sub-elements to be copied.
 As of now there it is under-specified, how to specify the sub-elements to include. One possible implementation would be a list where all element types can be mixed, since there might not be name conflicts across element types.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
-    add: Optional[Any] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
+    add: Optional[Any] = Field(default=None, description="""Add new sub-elements that are not present in the source element. Currently under-specified and not yet implemented (see issue #245).""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
 
 
 # Model rebuild

--- a/src/linkml_map/datamodel/transformer_model.py
+++ b/src/linkml_map/datamodel/transformer_model.py
@@ -760,7 +760,7 @@ class CopyDirective(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/linkml/transformer', 'status': 'testing'})
 
-    element_name: str = Field(default=..., description="""Name of the source element (class, slot, enum, etc.) this directive applies to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
+    element_name: str = Field(default=..., description="""Name of the source element this directive applies to (a class, slot, enum, etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     copy_all: Optional[bool] = Field(default=None, description="""Copy all sub-elements of the Element being derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     exclude_all: Optional[bool] = Field(default=None, description="""Do not copy any of the sub-elements of the Element being derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CopyDirective']} })
     exclude: Optional[Any] = Field(default=None, description="""Remove certain sub-elements from the list of sub-elements to be copied.

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -43,6 +43,10 @@ types:
 classes:
 
   Any:
+    description: >-
+      A wildcard type that accepts any value. Used where the model deliberately
+      avoids coupling to a specific range, such as embedded LinkML definition
+      objects.
     class_uri: linkml:Any
 
   SpecificationComponent:
@@ -96,6 +100,9 @@ classes:
         inlined: true
         slot_uri: sh:declare
       copy_directives:
+        description: >-
+          Directives controlling which elements of the source schema are
+          copied into the target schema.
         range: CopyDirective
         multivalued: true
         inlined: true
@@ -204,6 +211,9 @@ classes:
         identifier: true
         description: Name of the element in the target schema
       copy_directives:
+        description: >-
+          Directives controlling which sub-elements of the source element are
+          copied into the derived target element.
         range: CopyDirective
         multivalued: true
         inlined: true
@@ -213,9 +223,11 @@ classes:
         #multivalued: true
         #inlined: true
       is_a:
+        description: The parent element that the derived target element inherits from.
         range: ElementDerivation
         slot_uri: linkml:is_a
       mixins:
+        description: Mixin elements applied to the derived target element.
         range: ElementDerivation
         multivalued: true
         inlined: false
@@ -259,6 +271,9 @@ classes:
         description: >-
           A mapping table in which the keys and values are expressions
       mirror_source:
+        description: >-
+          If true, pass the source value through unchanged instead of
+          transforming it.
         range: boolean
 
 
@@ -291,6 +306,9 @@ classes:
         comments:
           - supports cross-table lookups via source_key/lookup_key or the join_on field
       slot_derivations:
+        description: >-
+          Instructions on how to derive the slots of this target class from
+          source data.
         range: SlotDerivation
         multivalued: true
         inlined: true
@@ -317,6 +335,9 @@ classes:
         description: Name of the element in the target schema
         required: false
       class_derivations:
+        description: >-
+          Class derivations used to construct nested instances for this
+          (deprecated) object derivation.
         range: ClassDerivation
         multivalued: true
         inlined: true
@@ -398,9 +419,15 @@ classes:
         description: >-
           A constant value to assign to the target slot.
       range:
+        description: >-
+          The range (value type) to assign to the derived target slot,
+          overriding the range inferred from the source.
         slot_uri: linkml:range
         range: string
       unit_conversion:
+        description: >-
+          Configuration for converting the source value's unit of measure when
+          deriving this slot.
         range: UnitConversionConfiguration
       inverse_of:
         range: Inverse
@@ -413,6 +440,9 @@ classes:
         range: boolean
         description: True if this is suppressed
       type_designator:
+        description: >-
+          True if this target slot designates the type (class) of the instance,
+          analogous to LinkML's designates_type.
         range: boolean
       target_definition:
         range: Any
@@ -421,12 +451,24 @@ classes:
         comments:
           - currently defined as Any to avoid coupling with metamodel
       cast_collection_as:
+        description: >-
+          Coerce the derived slot's collection form (for example single-valued,
+          list, or dictionary).
         range: CollectionType
       dictionary_key:
+        description: >-
+          When the derived value is a list of objects, the slot whose value is
+          used as the key to index them into a dictionary.
         range: string
       stringification:
+        description: >-
+          Configuration for combining multiple values into a single string
+          value.
         range: StringificationConfiguration
       aggregation_operation:
+        description: >-
+          An aggregation operation that reduces multiple source values into this
+          slot's value.
         range: AggregationOperation
       pivot_operation:
         range: PivotOperation
@@ -483,6 +525,10 @@ classes:
         key: true
         description: Target permissible value text
       expr:
+        description: >-
+          An expression evaluated on the source object to derive this
+          permissible value. Should be specified using the LinkML expression
+          language.
         range: string
       populated_from:
         range: string
@@ -498,27 +544,55 @@ classes:
         description: >-
           Deprecated. Use populated_from instead.
       hide:
+        description: True if this is suppressed
         range: boolean
 
   PrefixDerivation:
+    description: >-
+      A specification of how to derive a target prefix declaration. Currently a
+      placeholder with no additional fields.
     is_a: ElementDerivation
 
   UnitConversionConfiguration:
+    description: >-
+      Configuration for converting a slot value from a source unit of measure to
+      a target unit during transformation.
     attributes:
       target_unit:
+        description: >-
+          The unit to convert the value into. If omitted, the source unit is
+          used unchanged.
       target_unit_scheme:
+        description: The unit scheme or system identifying target_unit (for example ucum).
         range: string
         examples:
           - value: ucum
       source_unit:
+        description: >-
+          The unit the source value is expressed in. Cross-checked against any
+          unit declared on the source slot in the schema.
       source_unit_scheme:
+          description: The unit scheme or system identifying source_unit (for example ucum).
           range: string
           examples:
           - value: ucum
       source_unit_slot:
+        description: >-
+          For structured value-and-unit source input, the key within the source
+          value that holds the unit.
       source_magnitude_slot:
+        description: >-
+          For structured value-and-unit source input, the key within the source
+          value that holds the numeric magnitude.
       target_unit_slot:
+        description: >-
+          When emitting structured output, the key to write the target unit
+          into.
       target_magnitude_slot:
+        description: >-
+          When emitting structured output, the key to write the converted
+          magnitude into. Its presence makes the result a structured value
+          rather than a bare number.
       none_if_non_numeric:
         range: boolean
         description: >-
@@ -558,19 +632,30 @@ classes:
           Defaults to false (addition).
 
   StringificationConfiguration:
+    description: >-
+      Configuration for collapsing multiple values into a single delimited or
+      serialized string value.
     attributes:
       delimiter:
+        description: Delimiter used to join multiple values into a single string.
         range: string
         examples:
           - value: ','
           - value: '|'
           - value: ';'
       reversed:
+        description: >-
+          If true, reverse the operation, splitting a delimited or serialized
+          string back into multiple values.
         range: boolean
       over_slots:
+        description: The source slots whose values are combined into the stringified result.
         range: string
         multivalued: true
       syntax:
+        description: >-
+          Serialization syntax used to stringify the values when no delimiter is
+          given.
         range: SerializationSyntaxType
         examples:
           - value: 'json'
@@ -583,26 +668,38 @@ classes:
       - back_references
     attributes:
       slot_name:
+        description: Name of the slot on the referenced class that back-references the derived slot.
       class_name:
+        description: Name of the class that holds the back-reference (foreign key) slot.
 
   TransformationOperation:
     abstract: true
 
   AggregationOperation:
     is_a: TransformationOperation
+    description: >-
+      An operation that reduces multiple input values to a single value using an
+      aggregation function such as sum, average, or count.
     attributes:
       operator:
+        description: The aggregation function to apply (for example SUM, AVERAGE, COUNT).
         range: AggregationType
         required: true
       null_handling:
+        description: How to handle null values encountered during aggregation.
         range: InvalidValueHandlingStrategy
       invalid_value_handling:
+        description: >-
+          How to handle values that cannot be interpreted as valid input to the
+          aggregation.
         range: InvalidValueHandlingStrategy
 
   GroupingOperation:
     is_a: TransformationOperation
+    description: An operation that groups source rows prior to aggregation.
     attributes:
       null_handling:
+        description: How to handle null values when grouping.
         range: InvalidValueHandlingStrategy
 
   PivotOperation:
@@ -610,8 +707,12 @@ classes:
       - melt/unmelt
       - reification/dereification
     is_a: TransformationOperation
+    description: >-
+      An operation that reshapes data between wide and long (EAV)
+      representations, i.e. melt (wide to long) and unmelt (long to wide).
     attributes:
       direction:
+        description: Whether to MELT (wide to long) or UNMELT (long to wide).
         range: PivotDirectionType
         required: true
       variable_slot:
@@ -633,6 +734,9 @@ classes:
           representation) must conform to valid attributes in this class
         range: ClassReference
       unmelt_to_slots:
+        description: >-
+          For an unmelt operation, the target wide-format slots to populate from
+          the long/EAV rows.
         range: SlotReference
         multivalued: true
       unit_slot:
@@ -652,10 +756,13 @@ classes:
         description: Slots that identify the entity (not pivoted)
 
   KeyVal:
+    description: A generic key-value pair.
     attributes:
       key:
+        description: The key.
         key: true
       value:
+        description: The value associated with the key.
         range: Any
 
   # Aligned with fair_mappings_schema:Agent
@@ -733,6 +840,7 @@ classes:
     status: testing
     attributes:
       element_name:
+        description: Name of the source element (class, slot, enum, etc.) this directive applies to.
         key: true
       copy_all:
         range: boolean
@@ -755,6 +863,9 @@ classes:
           As of now there it is under-specified, how to specify the sub-elements to include.
           One possible implementation would be a list where all element types can be mixed, since there might not be name conflicts across element types.
       add:
+        description: >-
+          Add new sub-elements that are not present in the source element.
+          Currently under-specified and not yet implemented (see issue #245).
         range: Any
 
 enums:

--- a/src/linkml_map/datamodel/transformer_model.yaml
+++ b/src/linkml_map/datamodel/transformer_model.yaml
@@ -572,9 +572,9 @@ classes:
           The unit the source value is expressed in. Cross-checked against any
           unit declared on the source slot in the schema.
       source_unit_scheme:
-          description: The unit scheme or system identifying source_unit (for example ucum).
-          range: string
-          examples:
+        description: The unit scheme or system identifying source_unit (for example ucum).
+        range: string
+        examples:
           - value: ucum
       source_unit_slot:
         description: >-
@@ -840,7 +840,7 @@ classes:
     status: testing
     attributes:
       element_name:
-        description: Name of the source element (class, slot, enum, etc.) this directive applies to.
+        description: Name of the source element this directive applies to (a class, slot, enum, etc.).
         key: true
       copy_all:
         range: boolean


### PR DESCRIPTION
Adds `description:` to the 8 classes and 38 slots flagged in #240 (audited via `class_induced_slots()` — now reports zero gaps), then regenerates the pydantic model and schema docs.

- Descriptions grounded in actual engine usage, not guesses — e.g. the unit-conversion family (`source_unit_slot` / `*_magnitude_slot` etc.) is described from `_perform_unit_conversion`, and `CopyDirective.add` is documented as under-specified/unimplemented per #245.
- Doc churn is broad (76 files) because new class descriptions propagate into cross-reference tables; all of it traces to the description additions.

A few wording judgment calls worth a look in review: `type_designator` (no runtime handler; described from intent), `reversed` on stringification, and `add`.

Closes #240