### PR TITLE
Traverse inlined nested data in populated_from dot-paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -265,6 +265,27 @@ This requires:
 1. The source schema defines `org_id` with `range: Organization`
 2. The transformer has an `ObjectIndex` created via `transformer.index(container_data, "Container")`
 
+### Inlined Nested Data
+
+The same dot notation also traverses *inlined* nested objects (tree-shaped sources such
+as XML, JSON Schema, OWL, or EML), walking directly into the nested structure:
+
+```yaml
+class_derivations:
+  SchemaDefinition:
+    populated_from: EMLDocument
+    slot_derivations:
+      title:
+        populated_from: dataset.title  # 'title' inside the inlined 'dataset' object
+```
+
+A segment is treated as inline traversal when the source slot is declared `inlined` /
+`inlined_as_list`, or when the value is a nested object at runtime. No `ObjectIndex` is
+needed — the nested data is already present. Mapping each item of a multivalued inline
+list through a sibling class derivation is not yet supported
+([#265](https://github.com/linkml/linkml-map/issues/265)); such a path raises an error
+naming the multivalued segment.
+
 ### Schema Patches for Auto-Generated Schemas
 
 If your source schema doesn't define FK relationships (common with auto-generated schemas),

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -651,6 +651,8 @@ class ObjectTransformer(Transformer):
             (used for dot-notation without a matching join).
         :returns: Tuple of (resolved value, source slot definition or None).
         """
+        if "." in populated_from and self._is_inline_path(populated_from, context):
+            return self._resolve_inline_path(populated_from, slot_derivation, context)
         fk_resolution = resolve_fk_path(context.sv, context.source_type, populated_from)
         if fk_resolution:
             fk_value = context.source_obj.get(fk_resolution.fk_slot_name)
@@ -670,6 +672,96 @@ class ObjectTransformer(Transformer):
             )
         source_class_slot = context.sv.induced_slot(populated_from, context.source_type)
         return v, source_class_slot
+
+    def _is_inline_path(self, populated_from: str, context: DerivationContext) -> bool:
+        """Decide whether a dot-path traverses inlined nested data rather than an FK.
+
+        Detection is declarative first, with a runtime fallback (issue #247):
+
+        * **Declarative:** the first path segment's source slot has a class range
+          and is marked ``inlined`` / ``inlined_as_list``.
+        * **Runtime fallback:** the value at the first segment is actually a nested
+          object (dict) or list, even when the schema doesn't declare ``inlined``.
+
+        Foreign keys (class range, scalar identifier value, not inlined) fall
+        through to :func:`resolve_fk_path` as before.
+
+        :param populated_from: The dotted ``populated_from`` path.
+        :param context: Current derivation context.
+        :returns: True if the path should be walked structurally through inline data.
+        """
+        first_segment = populated_from.split(".", 1)[0]
+        try:
+            slot = context.sv.induced_slot(first_segment, context.source_type)
+        except Exception:
+            slot = None
+        if slot and slot.range in context.sv.all_classes() and (slot.inlined or slot.inlined_as_list):
+            return True
+        value = context.source_obj.get(first_segment) if isinstance(context.source_obj, dict) else None
+        return isinstance(value, dict | list)
+
+    def _resolve_inline_path(
+        self,
+        populated_from: str,
+        slot_derivation: SlotDerivation,
+        context: DerivationContext,
+    ) -> tuple[Any, SlotDefinition | None]:
+        """Walk a dot-path structurally through inlined nested objects (issue #247).
+
+        Descends into the nested dict(s) one segment at a time and returns the
+        leaf value together with its source slot (for range mapping). A segment
+        that is legitimately absent yields ``None`` rather than an error.
+
+        :param populated_from: The dotted ``populated_from`` path.
+        :param slot_derivation: The active slot derivation (for diagnostics).
+        :param context: Current derivation context.
+        :returns: Tuple of (leaf value, final source slot or None).
+        :raises TransformationError: if a segment holds a list (multivalued inline
+            fan-out, tracked in #265) or a non-dict value is encountered mid-path.
+        """
+        segments = populated_from.split(".")
+        current_val: Any = context.source_obj
+        current_class: str | None = context.source_type
+        final_slot: SlotDefinition | None = None
+
+        for i, segment in enumerate(segments):
+            if not isinstance(current_val, dict):
+                msg = (
+                    f"Cannot traverse inlined path {populated_from!r}: segment {segment!r} "
+                    f"expected a nested object but found {type(current_val).__name__}"
+                )
+                raise TransformationError(
+                    message=msg,
+                    slot_derivation_name=slot_derivation.name,
+                    slot_populated_from=populated_from,
+                )
+            slot = None
+            if current_class:
+                try:
+                    slot = context.sv.induced_slot(segment, current_class)
+                except Exception:
+                    slot = None
+            current_val = current_val.get(segment)
+            if isinstance(current_val, list):
+                msg = (
+                    f"Inlined path {populated_from!r} reaches a multivalued segment {segment!r}; "
+                    f"per-item fan-out to a matching class_derivation is not yet supported (see #265)"
+                )
+                raise TransformationError(
+                    message=msg,
+                    slot_derivation_name=slot_derivation.name,
+                    slot_populated_from=populated_from,
+                )
+            if i == len(segments) - 1:
+                final_slot = slot
+            elif slot and slot.range in context.sv.all_classes():
+                current_class = slot.range
+            else:
+                current_class = slot.range if slot else None
+            if current_val is None:
+                break
+
+        return current_val, final_slot
 
     def _resolve_joined_row(
         self,

--- a/tests/test_transformer/test_inline_dotpath.py
+++ b/tests/test_transformer/test_inline_dotpath.py
@@ -1,0 +1,141 @@
+"""Tests for inlined `populated_from` dot-path traversal (issue #247).
+
+`populated_from` dot-paths walk FK joins via ObjectIndex; #247 extends them to
+traverse *inlined* nested data (XML/JSON/OWL/EML-shaped trees) by walking into
+the nested object structurally instead of treating it as a foreign key.
+
+Scope of #247 (this file): slot-level traversal to a scalar leaf. Multivalued
+inline fan-out (a list segment auto-firing a sibling class_derivation per item)
+is tracked separately in #265 and here is asserted to raise a clear diagnostic.
+"""
+
+import pytest
+from linkml_runtime import SchemaView
+
+from linkml_map.transformer.errors import TransformationError
+from linkml_map.transformer.object_transformer import ObjectTransformer
+
+# Source: an EML-ish inlined tree. EMLDocument -> dataset (inlined) -> dataTable (inlined list).
+SOURCE_SCHEMA = """\
+id: https://example.org/eml-source
+name: eml-source
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  EMLDocument:
+    tree_root: true
+    attributes:
+      dataset:
+        range: Dataset
+        inlined: true
+  Dataset:
+    attributes:
+      title:
+        range: string
+      dataTable:
+        range: DataTable
+        multivalued: true
+        inlined_as_list: true
+  DataTable:
+    attributes:
+      entityName:
+        range: string
+"""
+
+# Target: a flattened LinkML-metamodel-ish shape.
+TARGET_SCHEMA = """\
+id: https://example.org/schema-target
+name: schema-target
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  SchemaDefinition:
+    tree_root: true
+    attributes:
+      title:
+        range: string
+      classes:
+        range: ClassDefinition
+        multivalued: true
+        inlined_as_list: true
+  ClassDefinition:
+    attributes:
+      name:
+        range: string
+"""
+
+INPUT_DATA = {
+    "dataset": {
+        "title": "My Dataset",
+        "dataTable": [
+            {"entityName": "table_one"},
+            {"entityName": "table_two"},
+        ],
+    },
+}
+
+
+def _make_transformer(transform_spec: dict, source_schema: str = SOURCE_SCHEMA) -> ObjectTransformer:
+    tr = ObjectTransformer(unrestricted_eval=False)
+    tr.source_schemaview = SchemaView(source_schema)
+    tr.target_schemaview = SchemaView(TARGET_SCHEMA)
+    tr.create_transformer_specification(transform_spec)
+    return tr
+
+
+def _title_spec() -> dict:
+    return {
+        "class_derivations": {
+            "SchemaDefinition": {
+                "populated_from": "EMLDocument",
+                "slot_derivations": {
+                    "title": {"populated_from": "dataset.title"},
+                },
+            },
+        },
+    }
+
+
+def test_slot_level_inline_deep_scalar():
+    """Dot-path into an inlined object reaches the scalar leaf without an ObjectIndex."""
+    tr = _make_transformer(_title_spec())
+    result = tr.map_object(INPUT_DATA, source_type="EMLDocument")
+    assert result["title"] == "My Dataset"
+
+
+def test_inline_path_via_runtime_fallback_without_inlined_declaration():
+    """A dict value traverses even when the source schema omits ``inlined: true``."""
+    source = SOURCE_SCHEMA.replace("        inlined: true\n", "")
+    tr = _make_transformer(_title_spec(), source_schema=source)
+    result = tr.map_object(INPUT_DATA, source_type="EMLDocument")
+    assert result["title"] == "My Dataset"
+
+
+def test_inline_path_absent_segment_yields_none():
+    """A legitimately missing leaf yields None rather than raising."""
+    tr = _make_transformer(_title_spec())
+    result = tr.map_object({"dataset": {}}, source_type="EMLDocument")
+    assert result.get("title") is None
+
+
+def test_multivalued_inline_segment_raises_clear_diagnostic():
+    """A list segment is the #265 fan-out case: raise naming the segment, not silent None."""
+    spec = {
+        "class_derivations": {
+            "SchemaDefinition": {
+                "populated_from": "EMLDocument",
+                "slot_derivations": {
+                    "classes": {"populated_from": "dataset.dataTable"},
+                },
+            },
+        },
+    }
+    tr = _make_transformer(spec)
+    with pytest.raises(TransformationError, match=r"dataTable.*#265"):
+        tr.map_object(INPUT_DATA, source_type="EMLDocument")


### PR DESCRIPTION
Closes #247 (slot-level scope).

`populated_from` dot-paths previously only resolved FK joins via `ObjectIndex`. For inlined sources (XML/JSON/OWL/EML trees) the FK path engaged, found no FK, warned `Cross-class lookup requires object_index`, and returned `None`.

- Detect inline references in `_resolve_fk_or_literal`: declaratively via `inlined`/`inlined_as_list`, with a runtime dict/list fallback.
- New `_resolve_inline_path` walks the nested structure segment by segment to the scalar leaf; no `ObjectIndex` needed.
- FK paths (class range, scalar identifier value) are unaffected.
- Absent leaf yields `None`; a multivalued inline segment raises a clear diagnostic naming the segment.

Scope is slot-level scalar leaves. Multivalued inline fan-out (per-item auto-fire of a sibling class_derivation) is split out to #265, and is what the new diagnostic points at.

## Tests
- `tests/test_transformer/test_inline_dotpath.py`: deep scalar, runtime-fallback (no `inlined:` declaration), absent segment → None, multivalued segment → diagnostic.
- Full suite: 941 passed, 4 skipped, 1 xfailed. `ruff check`/`format` clean.