### PR TITLE
Restore back-compat for string-form source_schema/target_schema

### DIFF
--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -305,8 +305,23 @@ class Transformer(ABC):
         cls._inherit_populated_from(obj)
         cls._coerce_pv_populated_from_to_list(obj)
         cls._migrate_pv_sources_to_populated_from(obj)
+        cls._coerce_schema_refs(obj)
 
         return messages
+
+    @staticmethod
+    def _coerce_schema_refs(obj: dict[str, Any]) -> None:
+        """Coerce bare-string ``source_schema``/``target_schema`` to object form.
+
+        The original spec form was a bare string (e.g. ``source_schema: my.yaml``);
+        the field now ranges over ``SchemaReference``. For backward compatibility
+        a string is rewritten to ``{"name": <string>}`` so legacy specs keep
+        loading. The pre-normalize scan reports the string form as deprecated.
+        """
+        for schema_field in ("source_schema", "target_schema"):
+            val = obj.get(schema_field)
+            if isinstance(val, str):
+                obj[schema_field] = {"name": val}
 
     @classmethod
     def _shape_normalize(cls, obj: dict[str, Any]) -> None:

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -466,6 +466,10 @@ def check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
       certainly didn't mean both. Severity: error.
     * ``object_derivations`` **and** ``class_derivations`` both set on
       the same ``SlotDerivation`` — ambiguous. Severity: error.
+    * ``source_schema`` / ``target_schema`` set to a bare string — the
+      original form, now superseded by the ``SchemaReference`` object
+      form (``{name: ...}``). Coerced at load time. Severity: warning,
+      category: deprecated.
 
     ``sources`` deprecation findings are collapsed to one message per
     (deprecation, derivation type) pair to keep output readable on
@@ -585,6 +589,21 @@ def check_deprecated_fields(data: dict[str, Any]) -> list[ValidationMessage]:
                 ),
             )
         )
+
+    for schema_field in ("source_schema", "target_schema"):
+        if isinstance(data.get(schema_field), str):
+            messages.append(
+                ValidationMessage(
+                    severity="warning",
+                    category="deprecated",
+                    path=f"$.{schema_field}",
+                    message=(
+                        f"'{schema_field}' is set to a bare string, which is deprecated. "
+                        f"Use the SchemaReference object form '{schema_field}: {{name: ...}}'. "
+                        f"The string form will be removed in a future version."
+                    ),
+                )
+            )
 
     return messages
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -224,6 +224,76 @@ def test_object_derivations_and_class_derivations_conflict():
         tr.create_transformer_specification(spec)
 
 
+@pytest.mark.parametrize("schema_field", ["source_schema", "target_schema"])
+def test_string_schema_ref_coerced_and_loads(schema_field):
+    """A bare-string source_schema/target_schema (the original form) still loads.
+
+    Regression for the SchemaReference change, which made the field range over an
+    object and silently broke every pre-existing string-form spec.
+    """
+    tr = ObjectTransformer()
+    spec = {
+        schema_field: "my_schema.yaml",
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        tr.create_transformer_specification(spec)
+
+    ref = getattr(tr.specification, schema_field)
+    assert ref is not None
+    assert ref.name == "my_schema.yaml"
+
+
+@pytest.mark.parametrize("schema_field", ["source_schema", "target_schema"])
+def test_string_schema_ref_emits_deprecation_warning(schema_field):
+    """A bare-string source_schema/target_schema emits a DeprecationWarning at load time."""
+    tr = ObjectTransformer()
+    spec = {
+        schema_field: "my_schema.yaml",
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+        },
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        tr.create_transformer_specification(spec)
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    schema_warnings = [w for w in deprecation_warnings if schema_field in str(w.message)]
+    assert len(schema_warnings) == 1
+    assert "bare string" in str(schema_warnings[0].message)
+
+
+def test_object_form_schema_ref_emits_no_warning():
+    """The SchemaReference object form for source_schema/target_schema is not deprecated."""
+    tr = ObjectTransformer()
+    spec = {
+        "source_schema": {"name": "src.yaml"},
+        "target_schema": {"name": "tgt.yaml"},
+        "class_derivations": {
+            "Person": {
+                "populated_from": "Person",
+                "slot_derivations": {"name": {"populated_from": "name"}},
+            },
+        },
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        tr.create_transformer_specification(spec)
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 0
+
+
 def test_no_warning_without_deprecated_fields():
     """No deprecation warning when no deprecated fields are used."""
     tr = ObjectTransformer()


### PR DESCRIPTION
Fixes #271.

The SchemaReference change made `source_schema`/`target_schema` range over an object, silently breaking every pre-existing string-form spec with a `ValidationError`. The string form is the original spelling, so this affected all specs written before this cycle.

- Coerce a bare string to `{name: ...}` in the MIGRATE phase of `_normalize_spec_dict` (model stays strictly `SchemaReference`, so `spec.source_schema.name` access is untouched; both load routes are covered).
- Flag the string form as deprecated in the SCAN phase — surfaces as a `DeprecationWarning` and through `validate-spec`. Removal of the string form is deferred to the next minor.
- Regression tests: old-form spec loads and coerces, emits the deprecation warning, object form stays warning-free.