### PR TITLE
Fix join memory blowup: respect container limits + lazy column-accumulating lookups

### DIFF
--- a/src/linkml_map/transformer/engine.py
+++ b/src/linkml_map/transformer/engine.py
@@ -12,44 +12,10 @@ from linkml_map.utils.lookup_index import LookupIndex
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from linkml_map.datamodel.transformer_model import ClassDerivation
     from linkml_map.loaders.data_loaders import DataLoader
     from linkml_map.transformer.object_transformer import ObjectTransformer
 
 logger = logging.getLogger(__name__)
-
-
-def _collect_all_joins(class_deriv: ClassDerivation) -> dict[str, tuple[str, str]]:
-    """Collect all join specs from a class derivation and its nested descendants.
-
-    Walks the slot_derivation tree recursively to find joins that were either
-    explicitly declared or synthesized during normalization.
-
-    :param class_deriv: Root class derivation to scan.
-    :returns: Dict of {table_name: (source_key, lookup_key)} for all joins found.
-    """
-    result: dict[str, tuple[str, str]] = {}
-
-    def _collect_from(cd: ClassDerivation) -> None:
-        if cd.joins:
-            for join_name, join_spec in cd.joins.items():
-                lookup_key = join_spec.lookup_key or join_spec.join_on
-                source_key = join_spec.source_key or join_spec.join_on
-                if not lookup_key or not source_key:
-                    msg = f"Join {join_name!r} must specify 'join_on' or both 'source_key' and 'lookup_key'"
-                    raise ValueError(msg)
-                existing = result.get(join_name)
-                if existing and existing != (source_key, lookup_key):
-                    msg = f"Conflicting join specs for {join_name!r}: {existing} vs ({source_key!r}, {lookup_key!r})"
-                    raise ValueError(msg)
-                result[join_name] = (source_key, lookup_key)
-        for sd in cd.slot_derivations.values():
-            if sd.class_derivations:
-                for nested_cd in sd.class_derivations:
-                    _collect_from(nested_cd)
-
-    _collect_from(class_deriv)
-    return result
 
 
 def transform_spec(
@@ -62,14 +28,15 @@ def transform_spec(
     Iterate class_derivation blocks and stream transformed rows.
 
     For each block whose ``populated_from`` names a loadable table, this
-    function:
+    function streams primary-table rows through
+    :meth:`ObjectTransformer.map_object`. Joined (secondary) tables are
+    registered **lazily** the first time a lookup needs them — and only the
+    columns actually referenced are materialized — so a wide secondary table
+    no longer loads in full. Registration uses ``data_loader.get_path``; a join
+    that references a missing data file therefore fails fast at first use.
 
-    1. Registers any ``joins`` as secondary tables in a :class:`LookupIndex`,
-       including joins synthesized during normalization for implicit cross-table
-       references.
-    2. Streams primary-table rows through
-       :meth:`ObjectTransformer.map_object`.
-    3. Drops secondary tables when the block is done.
+    At the end of each block, any sparse-join misses (source rows with no
+    matching joined row) are summarized at INFO.
 
     **LookupIndex ownership and cleanup:**
 
@@ -99,6 +66,8 @@ def transform_spec(
     owns_index = transformer.lookup_index is None
     if owns_index:
         transformer.lookup_index = LookupIndex()
+    # Resolve join table names to paths on demand, for lazy registration.
+    transformer.lookup_index.path_resolver = data_loader.get_path
 
     try:
         for class_deriv in spec.class_derivations:
@@ -107,34 +76,31 @@ def transform_spec(
                 logger.debug("Skipping class_derivation %s: no data found", class_deriv.name)
                 continue
 
-            joined_tables: list[str] = []
-            try:
-                # Register all joined tables (explicit + synthesized from normalization).
-                # _collect_all_joins walks nested derivations and validates each join spec.
-                all_joins = _collect_all_joins(class_deriv)
-                for join_name, (_source_key, lookup_key) in all_joins.items():
-                    if join_name in data_loader and not transformer.lookup_index.is_registered(join_name):
-                        join_path = data_loader.get_path(join_name)
-                        transformer.lookup_index.register_table(join_name, join_path, lookup_key)
-                        joined_tables.append(join_name)
+            transformer.join_miss_counts.clear()
+            row_count = 0
+            for row_idx, row in enumerate(data_loader[table_name]):
+                row_count = row_idx + 1
+                try:
+                    yield transformer.map_object(
+                        row,
+                        source_type=source_type or table_name,
+                        class_derivation=class_deriv,
+                    )
+                except TransformationError as err:
+                    if on_error is None:
+                        raise
+                    err.row_index = row_idx
+                    err.class_derivation_name = err.class_derivation_name or class_deriv.name
+                    on_error(err)
 
-                # Stream primary table rows
-                for row_idx, row in enumerate(data_loader[table_name]):
-                    try:
-                        yield transformer.map_object(
-                            row,
-                            source_type=source_type or table_name,
-                            class_derivation=class_deriv,
-                        )
-                    except TransformationError as err:
-                        if on_error is None:
-                            raise
-                        err.row_index = row_idx
-                        err.class_derivation_name = err.class_derivation_name or class_deriv.name
-                        on_error(err)
-            finally:
-                for jt in joined_tables:
-                    transformer.lookup_index.drop(jt)
+            for join_name, misses in sorted(transformer.join_miss_counts.items()):
+                logger.info(
+                    "join %r: %d of %d source rows had no matching row — nested object omitted",
+                    join_name,
+                    misses,
+                    row_count,
+                )
+            transformer.join_miss_counts.clear()
     finally:
         if owns_index:
             # Close the index we created and detach it so a second call on the

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -65,7 +65,7 @@ class _AmbiguousType:
 _AMBIGUOUS = _AmbiguousType()
 
 
-class LazyJoinRow(Mapping):
+class LazyJoinRow:
     """A joined-table row that materializes columns on first access.
 
     Seeded with the columns already loaded for the matched key, so the common
@@ -73,6 +73,13 @@ class LazyJoinRow(Mapping):
     one-time table rebuild (:meth:`LookupIndex.ensure_column`) and a refetch;
     accessing a column that is not in the table at all raises — a referenced
     column that does not exist is a spec error, not a null value.
+
+    This is the *single read path* for joined data. It is deliberately **not** a
+    ``Mapping`` and is intentionally not iterable: iterating or splatting it
+    (``dict(row)``, ``**row``) would touch every column and silently materialize
+    the entire table, defeating lazy loading. Such uses raise instead. Consumers
+    access columns by key (``row[col]`` / ``row.get(col)``) or check names via
+    :attr:`header` / :attr:`header_set`.
     """
 
     def __init__(
@@ -92,7 +99,7 @@ class LazyJoinRow(Mapping):
     def __getitem__(self, col: str) -> Any:  # noqa: ANN401
         if col in self._row:
             return self._row[col]  # present — value may be a legitimate None
-        if col in self._index.header(self._table):
+        if col in self._index.header_set(self._table):
             self._index.ensure_column(self._table, col)
             self._row = self._index.lookup_row(self._table, self._key_col, self._key_val) or {}
             return self._row.get(col)
@@ -102,16 +109,30 @@ class LazyJoinRow(Mapping):
         )
         raise TransformationError(message=msg)
 
-    def __iter__(self) -> Iterator:
-        return iter(self._index.header(self._table))
+    def get(self, col: str, default: Any = None) -> Any:  # noqa: ANN401
+        """Return ``self[col]``; ``default`` substitutes only a genuine null, never a missing column."""
+        value = self[col]  # raises if the column does not exist
+        return default if value is None else value
 
-    def __len__(self) -> int:
-        return len(self._index.header(self._table))
+    def __contains__(self, col: object) -> bool:
+        return isinstance(col, str) and col in self._index.header_set(self._table)
+
+    def __iter__(self) -> Any:  # noqa: ANN401
+        msg = (
+            "LazyJoinRow is not iterable; access columns by key. Iterating or "
+            "splatting it would materialize the entire joined table."
+        )
+        raise TypeError(msg)
 
     @property
     def header(self) -> list[str]:
         """All column names in the joined table (names only, no data load)."""
         return self._index.header(self._table)
+
+    @property
+    def header_set(self) -> set[str]:
+        """All column names as a ``set`` for O(1) membership checks."""
+        return self._index.header_set(self._table)
 
 
 class _LazyAttrView:
@@ -154,12 +175,14 @@ class MergedRow(dict):
 
     def __missing__(self, key: str) -> Any:  # noqa: ANN401
         """Resolve a joined column not present among the merged parent columns."""
-        if self._lazy_joined is not None and key in self._lazy_joined.header:
+        if isinstance(key, str) and self._lazy_joined is not None and key in self._lazy_joined.header_set:
             return self._lazy_joined[key]
         raise KeyError(key)
 
     def __contains__(self, key: object) -> bool:
-        return super().__contains__(key) or (self._lazy_joined is not None and key in self._lazy_joined.header)
+        return super().__contains__(key) or (
+            isinstance(key, str) and self._lazy_joined is not None and key in self._lazy_joined.header_set
+        )
 
     def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
         try:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -65,18 +65,107 @@ class _AmbiguousType:
 _AMBIGUOUS = _AmbiguousType()
 
 
+class LazyJoinRow(Mapping):
+    """A joined-table row that materializes columns on first access.
+
+    Seeded with the columns already loaded for the matched key, so the common
+    case is zero extra queries. Accessing a column not yet loaded triggers a
+    one-time table rebuild (:meth:`LookupIndex.ensure_column`) and a refetch;
+    accessing a column that is not in the table at all raises — a referenced
+    column that does not exist is a spec error, not a null value.
+    """
+
+    def __init__(
+        self,
+        index: Any,  # noqa: ANN401 - LookupIndex, duck-typed to keep duckdb optional
+        table: str,
+        key_col: str,
+        key_val: Any,  # noqa: ANN401
+        seed: dict,
+    ) -> None:
+        self._index = index
+        self._table = table
+        self._key_col = key_col
+        self._key_val = key_val
+        self._row = dict(seed)
+
+    def __getitem__(self, col: str) -> Any:  # noqa: ANN401
+        if col in self._row:
+            return self._row[col]  # present — value may be a legitimate None
+        if col in self._index.header(self._table):
+            self._index.ensure_column(self._table, col)
+            self._row = self._index.lookup_row(self._table, self._key_col, self._key_val) or {}
+            return self._row.get(col)
+        msg = (
+            f"Column {col!r} not found in join table {self._table!r}; "
+            f"available columns: {sorted(self._index.header(self._table))}."
+        )
+        raise TransformationError(message=msg)
+
+    def __iter__(self) -> Iterator:
+        return iter(self._index.header(self._table))
+
+    def __len__(self) -> int:
+        return len(self._index.header(self._table))
+
+    @property
+    def header(self) -> list[str]:
+        """All column names in the joined table (names only, no data load)."""
+        return self._index.header(self._table)
+
+
+class _LazyAttrView:
+    """Attribute-access wrapper over a :class:`LazyJoinRow` for ``expr`` bindings.
+
+    ``{Reading.score}`` reaches a joined column via attribute access; this
+    delegates ``.score`` to ``lazy['score']`` so resolution stays lazy. Dunder
+    names raise ``AttributeError`` so evaluator internals are never treated as
+    columns.
+    """
+
+    def __init__(self, lazy: LazyJoinRow) -> None:
+        object.__setattr__(self, "_lazy", lazy)
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return object.__getattribute__(self, "_lazy")[name]
+
+
 class MergedRow(dict):
     """A dict that remembers the original un-merged rows from an implicit join.
 
-    Behaves identically to a regular dict for all normal operations.
-    The original rows are accessible via :attr:`rows_by_table` so that
-    dot-notation disambiguation (e.g., ``Reading.id``) can resolve
-    ambiguous columns to table-specific values.
+    Behaves like a regular dict for parent columns, and resolves joined columns
+    lazily via :attr:`_lazy_joined` (so only accessed columns are loaded). The
+    original rows are accessible via :attr:`rows_by_table` so that dot-notation
+    disambiguation (e.g., ``Reading.id``) can resolve ambiguous columns to
+    table-specific values.
     """
 
-    def __init__(self, merged: dict, rows_by_table: dict[str, dict]) -> None:
+    def __init__(
+        self,
+        merged: dict,
+        rows_by_table: dict[str, dict],
+        lazy_joined: LazyJoinRow | None = None,
+    ) -> None:
         super().__init__(merged)
         self.rows_by_table = rows_by_table
+        self._lazy_joined = lazy_joined
+
+    def __missing__(self, key: str) -> Any:  # noqa: ANN401
+        """Resolve a joined column not present among the merged parent columns."""
+        if self._lazy_joined is not None and key in self._lazy_joined.header:
+            return self._lazy_joined[key]
+        raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        return super().__contains__(key) or (self._lazy_joined is not None and key in self._lazy_joined.header)
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
 
 def _raise_ambiguous_column(
@@ -219,7 +308,10 @@ class Bindings(Mapping):
             elif name in self.source_obj and self.source_obj[name] is _AMBIGUOUS:
                 _raise_ambiguous_column(name, class_deriv=self.class_deriv)
             elif isinstance(self.source_obj, MergedRow) and name in self.source_obj.rows_by_table:
-                self.bindings[name] = DynObj(**self.source_obj.rows_by_table[name])
+                entry = self.source_obj.rows_by_table[name]
+                # The joined entry is a LazyJoinRow — wrap for attribute access rather
+                # than DynObj(**entry), which would iterate and materialize every column.
+                self.bindings[name] = _LazyAttrView(entry) if isinstance(entry, LazyJoinRow) else DynObj(**entry)
             elif name == self.source_type and name not in self.source_obj:
                 # Self-reference: {Reading.score} when source_type is Reading (non-merge context)
                 self.bindings[name] = DynObj(**self.source_obj)
@@ -236,12 +328,12 @@ class Bindings(Mapping):
 
         return self.bindings.get(name)
 
-    def _resolve_join(self, table_name: str) -> DynObj | None:
-        """Resolve a cross-table lookup, returning a DynObj or None."""
+    def _resolve_join(self, table_name: str) -> _LazyAttrView | None:
+        """Resolve a cross-table lookup, returning a lazy attribute view or None."""
         row = self.object_transformer._resolve_joined_row(table_name, self.source_obj, self.class_deriv)
         if row is None:
             return None
-        return DynObj(**row)
+        return _LazyAttrView(row)
 
     def __setitem__(self, name: Any, value: Any) -> None:
         del name, value
@@ -270,6 +362,12 @@ class ObjectTransformer(Transformer):
 
     object_index: ObjectIndex = None
     lookup_index: Any = None  # Optional[LookupIndex] — lazy import to avoid hard duckdb dep
+
+    join_miss_counts: dict[str, int] = field(default_factory=dict)
+    """Per-join count of source rows with no matching joined row, for the current block.
+
+    Incremented on each sparse-join miss and summarized at INFO by ``transform_spec``
+    at the end of each block, then cleared. See :func:`~linkml_map.transformer.engine.transform_spec`."""
 
     extension_functions: dict[str, Callable] = field(default_factory=dict)
     """Custom safe functions to merge into the expression eval namespace.
@@ -788,17 +886,23 @@ class ObjectTransformer(Transformer):
         table_name: str,
         source_obj: DICT_OBJ,
         class_deriv: ClassDerivation,
-    ) -> dict | None:
+    ) -> LazyJoinRow | None:
         """Resolve a row from a joined table using LookupIndex.
 
         This is the single source of truth for cross-table join resolution.
         Both ``Bindings._resolve_join`` (for ``expr:``) and
         ``_perform_join_resolution`` (for ``populated_from:``) delegate here.
 
+        The table is registered lazily on first use (a missing data file fails
+        fast). ``None`` is returned only when the source key is null or no row in
+        the joined table matches — both legitimate sparse-join conditions (#217),
+        distinct from referencing a column that does not exist (which raises when
+        that column is later accessed on the returned :class:`LazyJoinRow`).
+
         :param table_name: Join name (key in ``class_deriv.joins``).
         :param source_obj: Current primary-table row.
         :param class_deriv: The active ClassDerivation (carries join specs).
-        :returns: Matched row as a dict, or ``None`` if no match found.
+        :returns: A :class:`LazyJoinRow` for the matched row, or ``None`` on a sparse miss.
         :raises ValueError: If join spec is missing keys or lookup_index is not initialized.
         """
         spec = class_deriv.joins[table_name]
@@ -813,7 +917,11 @@ class ObjectTransformer(Transformer):
         if self.lookup_index is None:
             msg = f"Join configured for {table_name!r} but lookup_index has not been initialized"
             raise ValueError(msg)
-        return self.lookup_index.lookup_row(table_name, lookup_key, key_val)
+        self.lookup_index.ensure_registered(table_name, lookup_key)
+        seed = self.lookup_index.lookup_row(table_name, lookup_key, key_val)
+        if seed is None:
+            return None
+        return LazyJoinRow(self.lookup_index, table_name, lookup_key, key_val, seed)
 
     def _perform_join_resolution(
         self,
@@ -829,7 +937,9 @@ class ObjectTransformer(Transformer):
         :returns: Tuple of (resolved value, source slot definition or None).
         """
         row = self._resolve_joined_row(table_name, context.source_obj, context.class_deriv)
-        v = row.get(field_path) if row else None
+        # row[field_path] raises if the column does not exist (spec error) and returns
+        # None for a genuine null; a sparse miss (row is None) yields None.
+        v = row[field_path] if row is not None else None
         joined_class = context.class_deriv.joins[table_name].class_named or table_name
         source_class_slot = None
         if joined_class in context.sv.all_classes():
@@ -840,32 +950,32 @@ class ObjectTransformer(Transformer):
     @staticmethod
     def _merge_rows(
         parent_row: DICT_OBJ,
-        joined_row: DICT_OBJ,
+        joined_row: LazyJoinRow,
         join_key: str,
         parent_source: str,
         nested_source: str,
     ) -> MergedRow:
         """Merge parent and joined rows, marking ambiguous columns.
 
-        Columns present in both rows (except the join key) are set to the
-        ``_AMBIGUOUS`` sentinel so that slot resolution raises a clear error
-        instead of silently picking one. The original rows are preserved in
-        the returned :class:`MergedRow` for dot-notation disambiguation.
+        Ambiguity is computed from the joined table's column *names* (its header),
+        so it is independent of which columns are lazily materialized — a column
+        present in both tables (except the join key) is set to the ``_AMBIGUOUS``
+        sentinel so that slot resolution raises a clear error instead of silently
+        picking one. Joined column *values* stay lazy: the returned
+        :class:`MergedRow` resolves them on access via ``joined_row``.
 
         :param parent_row: Row from the parent table.
-        :param joined_row: Row from the joined table.
+        :param joined_row: Lazy row from the joined table.
         :param join_key: The column used to join (kept from parent).
         :param parent_source: Parent table name (for logging).
         :param nested_source: Joined table name (for logging).
-        :returns: MergedRow with ambiguous markers and original rows.
+        :returns: MergedRow with ambiguous markers, parent values, and the lazy joined row.
         """
-        ambiguous = {k for k in parent_row if k in joined_row and k != join_key}
+        joined_cols = joined_row.header
+        ambiguous = {k for k in parent_row if k in joined_cols and k != join_key}
         merged = {}
         for k, v in parent_row.items():
             merged[k] = _AMBIGUOUS if k in ambiguous else v
-        for k, v in joined_row.items():
-            if k not in merged:
-                merged[k] = v
 
         if ambiguous:
             logger.debug(
@@ -875,7 +985,11 @@ class ObjectTransformer(Transformer):
                 nested_source,
             )
 
-        return MergedRow(merged, rows_by_table={parent_source: parent_row, nested_source: joined_row})
+        return MergedRow(
+            merged,
+            rows_by_table={parent_source: parent_row, nested_source: joined_row},
+            lazy_joined=joined_row,
+        )
 
     def _apply_offset(self, value: Any, slot_derivation: SlotDerivation, source_obj: DICT_OBJ) -> Any:
         """Apply an offset calculation using a value from another source field."""
@@ -964,6 +1078,7 @@ class ObjectTransformer(Transformer):
                             parent_source,
                             cls_derivation.name,
                         )
+                        self.join_miss_counts[nested_source] = self.join_miss_counts.get(nested_source, 0) + 1
                         continue
                     join_spec = parent_class_deriv.joins[nested_source]
                     join_key = join_spec.join_on or join_spec.source_key or ""

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -170,10 +170,14 @@ class _TableState:
     :ivar path: Source file path (string form, for DuckDB parameter binding).
     :ivar fmt: File format, used to rebuild the reader on column accumulation.
     :ivar key: Indexed key column.
-    :ivar materialized: Columns currently loaded into the DuckDB table.
+    :ivar materialized: Columns projected into the DuckDB table when ``full`` is
+        ``False``. When ``full`` is ``True`` the table holds *all* source columns
+        and this set is not authoritative (it only carries the key); column
+        accumulation is a no-op in that mode.
     :ivar full: ``True`` when the table was loaded with all columns (no projection);
         column accumulation is then a no-op.
     :ivar header: All column names in the source file, lazily read once via ``DESCRIBE``.
+    :ivar header_set: Cached ``set`` of :ivar:`header` for O(1) membership checks.
     """
 
     path: str
@@ -182,6 +186,7 @@ class _TableState:
     materialized: set[str]
     full: bool
     header: list[str] | None = None
+    header_set: set[str] | None = None
 
 
 class LookupIndex:
@@ -211,10 +216,11 @@ class LookupIndex:
 
     def _configure_connection(self) -> None:
         """Apply container-aware ``memory_limit``/``threads``/``temp_directory`` settings."""
-        for name, value in _resolve_duckdb_settings().items():
+        settings = _resolve_duckdb_settings()
+        for name, value in settings.items():
             literal = value if isinstance(value, int) else "'" + str(value).replace("'", "''") + "'"
             self._conn.execute(f"SET {name}={literal}")  # noqa: S608 - name is a fixed literal, value sanitized
-        logger.debug("Configured DuckDB connection: %s", _resolve_duckdb_settings())
+        logger.debug("Configured DuckDB connection: %s", settings)
 
     def register_table(
         self,
@@ -295,6 +301,13 @@ class LookupIndex:
             rows = self._conn.execute(f"DESCRIBE {select}", [st.path]).fetchall()  # noqa: S608
             st.header = [r[0] for r in rows]
         return st.header
+
+    def header_set(self, name: str) -> set[str]:
+        """Return :meth:`header` as a ``set`` for O(1) membership checks."""
+        st = self._tables[name]
+        if st.header_set is None:
+            st.header_set = set(self.header(name))
+        return st.header_set
 
     def lookup_row(
         self,

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -6,6 +6,8 @@ import logging
 import os
 import re
 import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -125,21 +127,61 @@ def _validate_identifier(name: str) -> None:
         raise ValueError(msg)
 
 
-def _duckdb_read_expr(fmt: FileFormat) -> str:
-    """Return a DuckDB ``SELECT ... FROM read_*()`` expression for *fmt*.
-
-    The returned SQL contains a single ``?`` placeholder for the file path.
+def _reader_source(fmt: FileFormat) -> str:
+    """Return the DuckDB ``read_*(...)`` table-function for *fmt* (one ``?`` for the path).
 
     :raises NotImplementedError: For formats without DuckDB reader support.
     """
     if fmt == FileFormat.TSV:
-        return "SELECT * FROM read_csv_auto(?, all_varchar=true, delim='\t', null_padding=true)"
+        return "read_csv_auto(?, all_varchar=true, delim='\t', null_padding=true)"
     if fmt == FileFormat.CSV:
-        return "SELECT * FROM read_csv_auto(?, all_varchar=true, delim=',', null_padding=true)"
+        return "read_csv_auto(?, all_varchar=true, delim=',', null_padding=true)"
     if fmt == FileFormat.JSON:
-        return "SELECT CAST(columns(*) AS VARCHAR) FROM read_json_auto(?)"
+        return "read_json_auto(?)"
     msg = f"LookupIndex does not yet support {fmt.value!r} files"
     raise NotImplementedError(msg)
+
+
+def _projected_select(fmt: FileFormat, columns: list[str] | None) -> str:
+    """Return a ``SELECT ... FROM read_*()`` statement, projected to *columns*.
+
+    When *columns* is ``None`` all columns are selected (``SELECT *``). JSON
+    values are cast to VARCHAR (matching the unprojected reader) so that joined
+    values coerce consistently with primary-table values.
+
+    :param fmt: File format.
+    :param columns: Columns to project, or ``None`` for all columns.
+    """
+    source = _reader_source(fmt)
+    if columns is None:
+        all_cols = "CAST(columns(*) AS VARCHAR)" if fmt == FileFormat.JSON else "*"
+        return f"SELECT {all_cols} FROM {source}"
+    if fmt == FileFormat.JSON:
+        projection = ", ".join(f"CAST({c} AS VARCHAR) AS {c}" for c in columns)
+    else:
+        projection = ", ".join(columns)
+    return f"SELECT {projection} FROM {source}"
+
+
+@dataclass
+class _TableState:
+    """Bookkeeping for one registered table.
+
+    :ivar path: Source file path (string form, for DuckDB parameter binding).
+    :ivar fmt: File format, used to rebuild the reader on column accumulation.
+    :ivar key: Indexed key column.
+    :ivar materialized: Columns currently loaded into the DuckDB table.
+    :ivar full: ``True`` when the table was loaded with all columns (no projection);
+        column accumulation is then a no-op.
+    :ivar header: All column names in the source file, lazily read once via ``DESCRIBE``.
+    """
+
+    path: str
+    fmt: FileFormat
+    key: str
+    materialized: set[str]
+    full: bool
+    header: list[str] | None = None
 
 
 class LookupIndex:
@@ -162,7 +204,10 @@ class LookupIndex:
         """
         self._conn = duckdb.connect(":memory:")
         self._configure_connection()
-        self._tables: dict[str, str] = {}  # table_name -> key_column
+        self._tables: dict[str, _TableState] = {}
+        #: Resolves a table name to its data file path. Set by the caller (engine)
+        #: to enable lazy registration on first lookup.
+        self.path_resolver: Callable[[str], Path] | None = None
 
     def _configure_connection(self) -> None:
         """Apply container-aware ``memory_limit``/``threads``/``temp_directory`` settings."""
@@ -171,7 +216,13 @@ class LookupIndex:
             self._conn.execute(f"SET {name}={literal}")  # noqa: S608 - name is a fixed literal, value sanitized
         logger.debug("Configured DuckDB connection: %s", _resolve_duckdb_settings())
 
-    def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
+    def register_table(
+        self,
+        name: str,
+        file_path: Path | str,
+        key_column: str,
+        columns: list[str] | None = None,
+    ) -> None:
         """
         Load a data file into DuckDB and create an index on *key_column*.
 
@@ -181,20 +232,69 @@ class LookupIndex:
         :param name: Logical table name (must be a valid identifier).
         :param file_path: Path to a data file.
         :param key_column: Column to index for lookups.
+        :param columns: Columns to load (the key is always included). ``None`` loads
+            all columns; an explicit list (possibly empty) enables lazy accumulation
+            via :meth:`ensure_column`.
         :raises NotImplementedError: If the file format is not yet supported (e.g. YAML).
         """
         _validate_identifier(name)
         _validate_identifier(key_column)
         file_path = Path(file_path)
         fmt = FileFormat.from_extension(file_path)
+        if columns is None:
+            materialized, full = {key_column}, True
+        else:
+            materialized = {key_column, *columns}
+            for col in materialized:
+                _validate_identifier(col)
+            full = False
+        self._tables[name] = _TableState(str(file_path), fmt, key_column, materialized, full)
+        self._build(name)
+
+    def _build(self, name: str) -> None:
+        """(Re)create the DuckDB table for *name* from its current materialized columns."""
+        st = self._tables[name]
+        select = _projected_select(st.fmt, None if st.full else sorted(st.materialized))
+        self._conn.execute(f"CREATE OR REPLACE TABLE {name} AS {select}", [st.path])  # noqa: S608
         self._conn.execute(
-            f"CREATE OR REPLACE TABLE {name} AS {_duckdb_read_expr(fmt)}",  # noqa: S608
-            [str(file_path)],
+            f"CREATE INDEX IF NOT EXISTS idx_{name}_{st.key} ON {name} ({st.key})"  # noqa: S608
         )
-        self._conn.execute(
-            f"CREATE INDEX IF NOT EXISTS idx_{name}_{key_column} ON {name} ({key_column})"  # noqa: S608
-        )
-        self._tables[name] = key_column
+
+    def ensure_registered(self, name: str, key_column: str) -> None:
+        """Lazily register *name* (key column only) on first use.
+
+        The file path is resolved via :attr:`path_resolver`; a missing file
+        therefore fails fast here rather than silently producing no matches.
+
+        :raises ValueError: If :attr:`path_resolver` has not been set.
+        """
+        if name in self._tables:
+            return
+        if self.path_resolver is None:
+            msg = "LookupIndex.path_resolver must be set before lazy registration"
+            raise ValueError(msg)
+        self.register_table(name, self.path_resolver(name), key_column, columns=[])
+
+    def ensure_column(self, name: str, column: str) -> None:
+        """Ensure *column* is materialized for *name*, rebuilding the table if needed.
+
+        No-op for tables loaded in full (unprojected) mode or columns already present.
+        """
+        st = self._tables[name]
+        if st.full or column in st.materialized:
+            return
+        _validate_identifier(column)
+        st.materialized.add(column)
+        self._build(name)
+
+    def header(self, name: str) -> list[str]:
+        """Return all column names in *name*'s source file, without loading data."""
+        st = self._tables[name]
+        if st.header is None:
+            select = _projected_select(st.fmt, None)
+            rows = self._conn.execute(f"DESCRIBE {select}", [st.path]).fetchall()  # noqa: S608
+            st.header = [r[0] for r in rows]
+        return st.header
 
     def lookup_row(
         self,
@@ -203,12 +303,15 @@ class LookupIndex:
         key_val: Any,  # noqa: ANN401
     ) -> dict[str, Any] | None:
         """
-        Return the first row matching *key_val* on *key_col*, or ``None``.
+        Return the first row matching *key_val* on *key_col*, or ``None`` if no row matches.
+
+        Only currently-materialized columns are returned; absent columns are
+        loaded on demand by :class:`LazyJoinRow` via :meth:`ensure_column`.
 
         :param table: Previously registered table name.
         :param key_col: Column to match on.
         :param key_val: Value to look up.
-        :returns: Row as a dict, or None if not found.
+        :returns: Row as a dict, or None if no row matches the key.
         """
         _validate_identifier(table)
         _validate_identifier(key_col)

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -10,8 +13,90 @@ import duckdb
 
 from linkml_map.loaders.data_loaders import FileFormat
 
+logger = logging.getLogger(__name__)
+
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _HAS_DIGIT_RE = re.compile(r"[0-9]")
+
+# DuckDB sizes its memory_limit (~80% of RAM) and thread pool from the *physical
+# host*, ignoring container cgroup limits. In a memory-capped container that lets
+# it allocate past the cap, so the kernel OOM-killer SIGKILLs the process (an
+# exit-less crash, no traceback) or it thrashes into a apparent hang. We detect
+# the cgroup limit and configure DuckDB to respect it, turning a silent OOM-kill
+# into a catchable OutOfMemoryException. See join-performance investigation.
+_MEMORY_FRACTION = 0.8  # leave headroom for the Python process / OS
+_CGROUP_V2_MEMORY = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_MEMORY = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_CGROUP_UNLIMITED = 1 << 62  # cgroup v1 "unlimited" sentinel is a near-max int
+_MEMORY_LIMIT_RE = re.compile(r"^\d+(\.\d+)?\s*([KMGT]i?B|%)?$", re.IGNORECASE)
+
+_ENV_MEMORY_LIMIT = "LINKML_MAP_DUCKDB_MEMORY_LIMIT"
+_ENV_THREADS = "LINKML_MAP_DUCKDB_THREADS"
+_ENV_TEMP_DIR = "LINKML_MAP_DUCKDB_TEMP_DIR"
+
+
+def _detect_cgroup_memory_bytes(paths: tuple[str, ...] = (_CGROUP_V2_MEMORY, _CGROUP_V1_MEMORY)) -> int | None:
+    """Return the container memory limit in bytes, or ``None`` if unlimited/undetectable.
+
+    Reads the cgroup v2 (``memory.max``) then v1 (``memory.limit_in_bytes``)
+    interfaces. A literal ``max`` (v2) or near-max sentinel (v1) means no limit.
+
+    :param paths: cgroup interface files to try, in order. Parameterized for testing.
+    """
+    for path in paths:
+        try:
+            raw = Path(path).read_text().strip()
+        except OSError:
+            continue
+        if raw == "max":
+            return None
+        value = int(raw)
+        if value >= _CGROUP_UNLIMITED:
+            return None
+        return value
+    return None
+
+
+def _resolve_duckdb_settings() -> dict[str, str | int]:
+    """Resolve DuckDB connection settings honoring the container and env overrides.
+
+    Precedence for each setting: explicit ``LINKML_MAP_DUCKDB_*`` env var, then a
+    value derived from the cgroup limit, then DuckDB's own default (omitted here).
+
+    - ``memory_limit``: ``_MEMORY_FRACTION`` of the detected cgroup limit, leaving
+      headroom for the rest of the process. Omitted when no limit is detected.
+    - ``threads``: the CPU affinity count (respects cpuset), so we don't spin a
+      host-sized thread pool on a few container vCPUs.
+    - ``temp_directory``: a concrete writable path so spillable operators have
+      somewhere to go (DuckDB's default can be a relative path).
+
+    :returns: Mapping of DuckDB setting name to value, ready to ``SET``.
+    """
+    settings: dict[str, str | int] = {}
+
+    memory_limit = os.environ.get(_ENV_MEMORY_LIMIT)
+    if not memory_limit:
+        cgroup_bytes = _detect_cgroup_memory_bytes()
+        if cgroup_bytes:
+            budget_mib = int(cgroup_bytes * _MEMORY_FRACTION) // (1024 * 1024)
+            memory_limit = f"{budget_mib}MiB"
+    if memory_limit:
+        if not _MEMORY_LIMIT_RE.match(memory_limit.strip()):
+            msg = f"Invalid DuckDB memory limit {memory_limit!r} (expected e.g. '2GB', '512MiB', '80%')"
+            raise ValueError(msg)
+        settings["memory_limit"] = memory_limit.strip()
+
+    threads = os.environ.get(_ENV_THREADS)
+    if threads:
+        settings["threads"] = int(threads)
+    elif hasattr(os, "sched_getaffinity"):
+        settings["threads"] = len(os.sched_getaffinity(0))
+    elif os.cpu_count():
+        settings["threads"] = os.cpu_count()
+
+    settings["temp_directory"] = os.environ.get(_ENV_TEMP_DIR) or tempfile.gettempdir()
+
+    return settings
 
 
 def _parse_numeric(value: str) -> int | float | str:
@@ -69,9 +154,22 @@ class LookupIndex:
     """
 
     def __init__(self) -> None:
-        """Initialize an empty lookup index with an in-memory DuckDB connection."""
+        """Initialize an empty lookup index with an in-memory DuckDB connection.
+
+        The connection is configured to respect container cgroup limits (memory
+        and CPU) rather than DuckDB's host-derived defaults, so a memory-capped
+        container fails with a catchable error instead of being OOM-killed.
+        """
         self._conn = duckdb.connect(":memory:")
+        self._configure_connection()
         self._tables: dict[str, str] = {}  # table_name -> key_column
+
+    def _configure_connection(self) -> None:
+        """Apply container-aware ``memory_limit``/``threads``/``temp_directory`` settings."""
+        for name, value in _resolve_duckdb_settings().items():
+            literal = value if isinstance(value, int) else "'" + str(value).replace("'", "''") + "'"
+            self._conn.execute(f"SET {name}={literal}")  # noqa: S608 - name is a fixed literal, value sanitized
+        logger.debug("Configured DuckDB connection: %s", _resolve_duckdb_settings())
 
     def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
         """

--- a/tests/test_transformer/test_cross_table_lookup.py
+++ b/tests/test_transformer/test_cross_table_lookup.py
@@ -15,6 +15,7 @@ from linkml_runtime import SchemaView
 
 from linkml_map.loaders.data_loaders import DataLoader
 from linkml_map.transformer.engine import transform_spec
+from linkml_map.transformer.errors import TransformationError
 from linkml_map.transformer.object_transformer import ObjectTransformer
 
 # ---- fixtures ----
@@ -312,7 +313,11 @@ def test_multiple_joined_tables(data_dir, source_sv, target_sv, tmp_path):
 
 
 def test_join_spec_missing_key_raises(source_sv, target_sv, data_dir):
-    """A join spec with neither `on` nor source_key/lookup_key raises ValueError."""
+    """A join spec with neither `on` nor source_key/lookup_key raises when the join is used.
+
+    Validation is lazy (at first lookup), so the underlying ValueError surfaces
+    wrapped in a TransformationError carrying slot context.
+    """
     spec = textwrap.dedent("""\
         class_derivations:
           MeasurementObservation:
@@ -327,7 +332,7 @@ def test_join_spec_missing_key_raises(source_sv, target_sv, data_dir):
     """)
     tr = _make_transformer(source_sv, target_sv, spec)
     loader = DataLoader(data_dir)
-    with pytest.raises(ValueError, match="must specify"):
+    with pytest.raises(TransformationError, match="must specify"):
         list(transform_spec(tr, loader))
 
 
@@ -393,7 +398,12 @@ def test_populated_from_cross_table_no_match(data_dir, source_sv, target_sv):
 
 
 def test_populated_from_cross_table_missing_field(data_dir, source_sv, target_sv):
-    """When joined row exists but the requested field doesn't, return None."""
+    """Referencing a column absent from the joined table fails hard.
+
+    A column that does not exist in the join table is a spec error (a slot you
+    described isn't there), distinct from a column that exists with a null value.
+    It must raise rather than silently resolve to None.
+    """
     spec = textwrap.dedent("""\
         class_derivations:
           MeasurementObservation:
@@ -409,10 +419,8 @@ def test_populated_from_cross_table_missing_field(data_dir, source_sv, target_sv
     """)
     tr = _make_transformer(source_sv, target_sv, spec)
     loader = DataLoader(data_dir)
-    results = list(transform_spec(tr, loader))
-
-    assert results[0]["sample_id"] == "S001"
-    assert results[0].get("nonexistent") is None
+    with pytest.raises(TransformationError, match="not found in join table"):
+        list(transform_spec(tr, loader))
 
 
 def test_populated_from_with_value_mappings(data_dir, source_sv, target_sv):

--- a/tests/test_transformer/test_lazy_join.py
+++ b/tests/test_transformer/test_lazy_join.py
@@ -1,0 +1,158 @@
+"""End-to-end tests for lazy join materialization, sparse-miss logging, and fail-fast.
+
+These exercise the streaming engine path: joined tables register on first use and
+accumulate only referenced columns; sparse misses are summarized at INFO; and a join
+referencing a missing data file fails hard rather than silently producing no matches.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import textwrap
+
+import pytest
+import yaml
+from linkml_runtime import SchemaView
+
+from linkml_map.loaders.data_loaders import DataLoader
+from linkml_map.session import Session
+from linkml_map.transformer.engine import transform_spec
+from linkml_map.transformer.errors import TransformationError
+from linkml_map.utils.lookup_index import LookupIndex
+
+SOURCE_SCHEMA = yaml.safe_load(
+    textwrap.dedent("""\
+    id: https://example.org/lazy-join-test
+    name: lazy_join_test
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: lazy_join_test
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      Measurement:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+          method: {range: string}
+      Reading:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+          score: {range: float}
+    """)
+)
+
+TRANSFORM_SPEC = yaml.safe_load(
+    textwrap.dedent("""\
+    id: lazy-join-transform
+    title: Lazy join
+    class_derivations:
+      Result:
+        populated_from: Measurement
+        slot_derivations:
+          id:
+          method:
+          observation:
+            class_derivations:
+              - Observation:
+                  populated_from: Reading
+                  slot_derivations:
+                    value:
+                      populated_from: score
+    """)
+)
+
+TARGET_SCHEMA = textwrap.dedent("""\
+    id: https://example.org/lazy-join-target
+    name: lazy_join_target
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: lazy_join_target
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      Result:
+        attributes:
+          id: {identifier: true}
+          method: {range: string}
+          observation: {range: Observation, inlined: true}
+      Observation:
+        attributes:
+          value: {range: float}
+""")
+
+
+def _make_transformer():
+    session = Session()
+    session.set_source_schema(SOURCE_SCHEMA)
+    session.set_object_transformer(TRANSFORM_SPEC)
+    tr = session.object_transformer
+    tr.source_schemaview = session.source_schemaview
+    tr.target_schemaview = SchemaView(TARGET_SCHEMA)
+    return tr
+
+
+def _write_measurement(path, subjects):
+    with open(path / "Measurement.tsv", "w", newline="") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(["id", "subject_id", "method"])
+        for i, s in enumerate(subjects):
+            w.writerow([f"M{i}", s, "spirometry"])
+
+
+def _write_wide_reading(path, subjects, n_extra=200):
+    cols = ["id", "subject_id", "score", *[f"extra{j}" for j in range(n_extra)]]
+    with open(path / "Reading.tsv", "w", newline="") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(cols)
+        for i, s in enumerate(subjects):
+            w.writerow([f"R{i}", s, 95.5, *[f"v{i}_{j}" for j in range(n_extra)]])
+
+
+def test_wide_join_table_materializes_only_referenced_columns(tmp_path):
+    """A wide joined table loads only the key + the one referenced column."""
+    subjects = [f"S{i}" for i in range(10)]
+    _write_measurement(tmp_path, subjects)
+    _write_wide_reading(tmp_path, subjects, n_extra=200)
+
+    tr = _make_transformer()
+    idx = LookupIndex()
+    tr.lookup_index = idx  # pre-attach to inspect after the run
+    loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
+
+    results = list(transform_spec(tr, loader, source_type="Measurement"))
+
+    assert results[0]["observation"]["value"] == 95.5
+    assert len(idx.header("Reading")) == 203  # id, subject_id, score, extra0..199
+    assert idx._tables["Reading"].materialized == {"subject_id", "score"}
+    idx.close()
+
+
+def test_sparse_miss_logs_info_summary(tmp_path, caplog):
+    """End-of-block summary reports the count of source rows with no matching join row."""
+    _write_measurement(tmp_path, ["S0", "S1", "S_NOPE", "S_ALSO_NOPE"])
+    _write_wide_reading(tmp_path, ["S0", "S1"], n_extra=3)
+
+    tr = _make_transformer()
+    loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
+
+    with caplog.at_level(logging.INFO, logger="linkml_map.transformer.engine"):
+        results = list(transform_spec(tr, loader, source_type="Measurement"))
+
+    assert len(results) == 4
+    summaries = [r.message for r in caplog.records if "had no matching row" in r.message]
+    assert len(summaries) == 1
+    assert "2 of 4" in summaries[0]
+    assert "Reading" in summaries[0]
+
+
+def test_absent_join_file_fails_hard(tmp_path):
+    """A join that references a table with no data file fails fast at first use."""
+    _write_measurement(tmp_path, ["S0", "S1"])
+    # Deliberately do NOT write Reading.tsv
+
+    tr = _make_transformer()
+    loader = DataLoader(tmp_path, schemaview=tr.source_schemaview)
+
+    with pytest.raises(TransformationError, match="No data file found"):
+        list(transform_spec(tr, loader, source_type="Measurement"))

--- a/tests/test_transformer/test_lazy_join.py
+++ b/tests/test_transformer/test_lazy_join.py
@@ -146,6 +146,37 @@ def test_sparse_miss_logs_info_summary(tmp_path, caplog):
     assert "Reading" in summaries[0]
 
 
+def test_lazy_join_row_not_splattable(tmp_path):
+    """Iterating/splatting a LazyJoinRow fails loudly instead of materializing every column.
+
+    A LazyJoinRow is intentionally not a Mapping: ``dict(row)`` / ``**row`` / iteration
+    would touch every column and silently load the whole table, defeating lazy loading.
+    """
+    from linkml_map.transformer.object_transformer import LazyJoinRow
+
+    _write_measurement(tmp_path, ["S0"])
+    _write_wide_reading(tmp_path, ["S0"], n_extra=5)
+    idx = LookupIndex()
+    idx.path_resolver = lambda _name: tmp_path / "Reading.tsv"
+    idx.ensure_registered("Reading", "subject_id")
+    row = LazyJoinRow(idx, "Reading", "subject_id", "S0", idx.lookup_row("Reading", "subject_id", "S0"))
+
+    # Key/name access works and stays lazy.
+    assert row["subject_id"] == "S0"
+    assert "score" in row
+    assert "nonexistent" not in row
+    assert idx._tables["Reading"].materialized == {"subject_id"}  # nothing extra materialized
+
+    # Iteration / splat / dict-coercion must raise, not silently materialize.
+    with pytest.raises(TypeError):
+        list(row)
+    with pytest.raises(TypeError):
+        dict(row)
+    with pytest.raises(TypeError):
+        {**row}  # noqa: B018
+    idx.close()
+
+
 def test_absent_join_file_fails_hard(tmp_path):
     """A join that references a table with no data file fails fast at first use."""
     _write_measurement(tmp_path, ["S0", "S1"])

--- a/tests/test_utils/test_lookup_index_lazy.py
+++ b/tests/test_utils/test_lookup_index_lazy.py
@@ -1,0 +1,87 @@
+"""Tests for lazy registration and on-demand column accumulation in LookupIndex.
+
+A joined table is registered with only its key column, then accumulates columns
+as they are accessed — so a wide secondary table never loads in full. Referencing
+a column that does not exist is a spec error and raises; a column that exists with
+a null value returns None.
+"""
+
+from __future__ import annotations
+
+import csv
+
+import pytest
+
+from linkml_map.utils.lookup_index import LookupIndex
+
+
+@pytest.fixture()
+def wide_csv(tmp_path):
+    """A 'Reading' table with a key, one useful column, and many unused wide columns."""
+    path = tmp_path / "Reading.csv"
+    cols = ["subject_id", "score", *[f"extra{j}" for j in range(50)]]
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(cols)
+        for i in range(20):
+            w.writerow([f"S{i}", i, *[f"v{i}_{j}" for j in range(50)]])
+    return path
+
+
+def test_lazy_registration_loads_key_only(wide_csv):
+    """ensure_registered materializes just the key column."""
+    with LookupIndex() as idx:
+        idx.path_resolver = lambda _name: wide_csv
+        idx.ensure_registered("Reading", "subject_id")
+        assert idx._tables["Reading"].materialized == {"subject_id"}
+
+
+def test_ensure_registered_requires_path_resolver(wide_csv):
+    """Lazy registration without a path resolver fails fast."""
+    with LookupIndex() as idx:
+        with pytest.raises(ValueError, match="path_resolver"):
+            idx.ensure_registered("Reading", "subject_id")
+
+
+def test_column_accumulates_on_demand(wide_csv):
+    """ensure_column adds exactly the requested column and no others."""
+    with LookupIndex() as idx:
+        idx.path_resolver = lambda _name: wide_csv
+        idx.ensure_registered("Reading", "subject_id")
+        idx.ensure_column("Reading", "score")
+        assert idx._tables["Reading"].materialized == {"subject_id", "score"}
+        # Repeat access does not re-add or change the set.
+        idx.ensure_column("Reading", "score")
+        assert idx._tables["Reading"].materialized == {"subject_id", "score"}
+
+
+def test_header_lists_all_columns_without_materializing(wide_csv):
+    """header() exposes all column names while only the key stays materialized."""
+    with LookupIndex() as idx:
+        idx.path_resolver = lambda _name: wide_csv
+        idx.ensure_registered("Reading", "subject_id")
+        header = idx.header("Reading")
+        assert "score" in header
+        assert len([c for c in header if c.startswith("extra")]) == 50
+        # header read does not pull columns into the table
+        assert idx._tables["Reading"].materialized == {"subject_id"}
+
+
+def test_lookup_returns_only_materialized_columns(wide_csv):
+    """A lookup returns the key plus accumulated columns, not the whole wide row."""
+    with LookupIndex() as idx:
+        idx.path_resolver = lambda _name: wide_csv
+        idx.ensure_registered("Reading", "subject_id")
+        idx.ensure_column("Reading", "score")
+        row = idx.lookup_row("Reading", "subject_id", "S3")
+        assert row == {"subject_id": "S3", "score": 3}
+
+
+def test_register_table_full_load_is_backward_compatible(wide_csv):
+    """register_table without a columns list still loads every column (legacy callers)."""
+    with LookupIndex() as idx:
+        idx.register_table("Reading", wide_csv, "subject_id")
+        row = idx.lookup_row("Reading", "subject_id", "S1")
+        assert row["score"] == 1
+        assert row["extra0"] == "v1_0"
+        assert idx._tables["Reading"].full is True

--- a/tests/test_utils/test_lookup_index_resource_limits.py
+++ b/tests/test_utils/test_lookup_index_resource_limits.py
@@ -1,0 +1,113 @@
+"""Tests for container-aware DuckDB resource configuration on LookupIndex.
+
+DuckDB sizes memory_limit/threads from the physical host and ignores cgroup
+limits, which lets a memory-capped container be OOM-killed (an exit-less crash)
+instead of failing with a catchable error. LookupIndex configures the connection
+to respect the container; these tests verify that wiring.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from linkml_map.utils.lookup_index import (
+    _CGROUP_UNLIMITED,
+    _ENV_MEMORY_LIMIT,
+    _ENV_THREADS,
+    LookupIndex,
+    _detect_cgroup_memory_bytes,
+    _resolve_duckdb_settings,
+)
+
+
+def _current_setting(index: LookupIndex, name: str) -> str:
+    return index._conn.execute(f"SELECT current_setting('{name}')").fetchone()[0]
+
+
+# --- cgroup detection ---
+
+
+def test_detect_cgroup_v2_limit(tmp_path):
+    """A numeric cgroup v2 memory.max is parsed to bytes."""
+    f = tmp_path / "memory.max"
+    f.write_text("4294967296\n")  # 4 GiB
+    assert _detect_cgroup_memory_bytes((str(f),)) == 4294967296
+
+
+def test_detect_cgroup_v2_unlimited(tmp_path):
+    """A literal 'max' means no limit."""
+    f = tmp_path / "memory.max"
+    f.write_text("max\n")
+    assert _detect_cgroup_memory_bytes((str(f),)) is None
+
+
+def test_detect_cgroup_v1_unlimited_sentinel(tmp_path):
+    """A near-max v1 sentinel is treated as unlimited, not a real limit."""
+    f = tmp_path / "memory.limit_in_bytes"
+    f.write_text(f"{_CGROUP_UNLIMITED + 4096}\n")
+    assert _detect_cgroup_memory_bytes((str(f),)) is None
+
+
+def test_detect_cgroup_missing_files_returns_none(tmp_path):
+    """No readable cgroup file (e.g. local dev) yields None rather than raising."""
+    assert _detect_cgroup_memory_bytes((str(tmp_path / "nope"),)) is None
+
+
+def test_detect_cgroup_prefers_first_present(tmp_path):
+    """The first readable path wins (v2 before v1)."""
+    v2 = tmp_path / "memory.max"
+    v2.write_text("2147483648")  # 2 GiB
+    v1 = tmp_path / "memory.limit_in_bytes"
+    v1.write_text("1073741824")  # 1 GiB
+    assert _detect_cgroup_memory_bytes((str(v2), str(v1))) == 2147483648
+
+
+# --- settings resolution ---
+
+
+def test_env_memory_limit_overrides(monkeypatch):
+    """An explicit env memory limit is honored verbatim."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "1500MiB")
+    assert _resolve_duckdb_settings()["memory_limit"] == "1500MiB"
+
+
+def test_env_threads_overrides(monkeypatch):
+    """An explicit env thread count is honored and coerced to int."""
+    monkeypatch.setenv(_ENV_THREADS, "3")
+    assert _resolve_duckdb_settings()["threads"] == 3
+
+
+def test_invalid_memory_limit_raises(monkeypatch):
+    """A malformed memory limit fails fast rather than reaching DuckDB."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "lots of ram")
+    with pytest.raises(ValueError, match="Invalid DuckDB memory limit"):
+        _resolve_duckdb_settings()
+
+
+def test_threads_default_to_affinity(monkeypatch):
+    """Without an override, threads default to the CPU affinity count (respects cpuset)."""
+    monkeypatch.delenv(_ENV_THREADS, raising=False)
+    expected = len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else os.cpu_count()
+    assert _resolve_duckdb_settings()["threads"] == expected
+
+
+def test_temp_directory_always_set(monkeypatch):
+    """A concrete temp_directory is always provided so spilling has a target."""
+    monkeypatch.delenv("LINKML_MAP_DUCKDB_TEMP_DIR", raising=False)
+    assert _resolve_duckdb_settings()["temp_directory"]
+
+
+# --- end-to-end: settings actually land on the connection ---
+
+
+def test_connection_applies_env_settings(monkeypatch):
+    """Constructing a LookupIndex applies env-configured settings to the live connection."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "512MiB")
+    monkeypatch.setenv(_ENV_THREADS, "2")
+    with LookupIndex() as index:
+        assert int(_current_setting(index, "threads")) == 2
+        # DuckDB echoes memory_limit as a human string (e.g. "512.0 MiB"); assert it
+        # reflects our 512MiB request rather than the multi-GiB host default.
+        assert "512" in str(_current_setting(index, "memory_limit"))


### PR DESCRIPTION
Join-heavy transforms were hanging / getting OOM-killed on modest containers. Two compounding causes, two fixes.

**Container limits (P1)**
- DuckDB sized `memory_limit` (~80% RAM) and `threads` from the physical host, ignoring cgroup limits — so a memory-capped container allocated past its cap and got SIGKILLed (exit-less crash) or thrashed.
- `LookupIndex` now reads the cgroup limit and sets `memory_limit`/`threads`/`temp_directory`, with `LINKML_MAP_DUCKDB_*` overrides. Over-large loads now raise a catchable `OutOfMemoryException` instead of being OOM-killed.

**Lazy, column-accumulating joins**
- Joined tables loaded whole (`SELECT *`) up front, so a wide secondary table blew memory before any rows streamed.
- Tables now register on first lookup with only the key column and accumulate columns on demand; a wide table materializes only what's referenced (verified: 303-col table → 2 columns loaded).
- `LazyJoinRow` is the single chokepoint for all three consumers (`populated_from` dotted, merged nested row, expr binding). Column names come from a cheap header read, so ambiguity detection is unchanged while only accessed column data loads.
- Referencing a column absent from a join table, or a join to a missing data file, now fails hard. `None` is reserved for genuine nulls and #217 sparse row-misses, which are summarized per block at INFO (per-row detail stays at DEBUG).
- `transform_spec` drops `_collect_all_joins` and the per-block register/drop scaffolding; tables register once and live to `close()`.

**Behavior changes**
- Missing join column: previously resolved to `None`, now raises `TransformationError`.
- Missing join data file (for a used join): previously an opaque DuckDB error, now a clear "no data file found".
- Join-spec validation is lazy (at first use) and surfaces wrapped in `TransformationError` with slot context.

**Tests**
- New: `test_lookup_index_resource_limits.py`, `test_lookup_index_lazy.py`, `test_lazy_join.py`.
- Updated two `test_cross_table_lookup.py` cases to the fail-hard semantics.
- Full suite: 975 passed, 4 skipped, 1 xfailed.