### PR TITLE
Configure DuckDB to respect container cgroup limits

### DIFF
--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -101,7 +101,7 @@ def _resolve_duckdb_settings() -> dict[str, str | int]:
     elif os.cpu_count():
         settings["threads"] = os.cpu_count()
 
-    settings["temp_directory"] = os.environ.get(_ENV_TEMP_DIR) or tempfile.gettempdir()
+    settings["temp_directory"] = os.environ.get(_ENV_TEMP_DIR, "").strip() or tempfile.gettempdir()
 
     return settings
 

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -89,7 +89,7 @@ def _resolve_duckdb_settings() -> dict[str, str | int]:
             raise ValueError(msg)
         settings["memory_limit"] = memory_limit.strip()
 
-    threads = os.environ.get(_ENV_THREADS)
+    threads = os.environ.get(_ENV_THREADS, "").strip()
     if threads:
         value = int(threads) if threads.lstrip("-").isdigit() else None
         if value is None or value < 1:

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -21,7 +21,7 @@ _HAS_DIGIT_RE = re.compile(r"[0-9]")
 # DuckDB sizes its memory_limit (~80% of RAM) and thread pool from the *physical
 # host*, ignoring container cgroup limits. In a memory-capped container that lets
 # it allocate past the cap, so the kernel OOM-killer SIGKILLs the process (an
-# exit-less crash, no traceback) or it thrashes into a apparent hang. We detect
+# exit-less crash, no traceback) or it thrashes into an apparent hang. We detect
 # the cgroup limit and configure DuckDB to respect it, turning a silent OOM-kill
 # into a catchable OutOfMemoryException. See join-performance investigation.
 _MEMORY_FRACTION = 0.8  # leave headroom for the Python process / OS
@@ -50,7 +50,10 @@ def _detect_cgroup_memory_bytes(paths: tuple[str, ...] = (_CGROUP_V2_MEMORY, _CG
             continue
         if raw == "max":
             return None
-        value = int(raw)
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
         if value >= _CGROUP_UNLIMITED:
             return None
         return value
@@ -78,7 +81,7 @@ def _resolve_duckdb_settings() -> dict[str, str | int]:
     if not memory_limit:
         cgroup_bytes = _detect_cgroup_memory_bytes()
         if cgroup_bytes:
-            budget_mib = int(cgroup_bytes * _MEMORY_FRACTION) // (1024 * 1024)
+            budget_mib = max(1, int(cgroup_bytes * _MEMORY_FRACTION) // (1024 * 1024))
             memory_limit = f"{budget_mib}MiB"
     if memory_limit:
         if not _MEMORY_LIMIT_RE.match(memory_limit.strip()):
@@ -88,7 +91,11 @@ def _resolve_duckdb_settings() -> dict[str, str | int]:
 
     threads = os.environ.get(_ENV_THREADS)
     if threads:
-        settings["threads"] = int(threads)
+        value = int(threads) if threads.lstrip("-").isdigit() else None
+        if value is None or value < 1:
+            msg = f"Invalid DuckDB thread count {threads!r} (expected a positive integer)"
+            raise ValueError(msg)
+        settings["threads"] = value
     elif hasattr(os, "sched_getaffinity"):
         settings["threads"] = len(os.sched_getaffinity(0))
     elif os.cpu_count():
@@ -166,10 +173,11 @@ class LookupIndex:
 
     def _configure_connection(self) -> None:
         """Apply container-aware ``memory_limit``/``threads``/``temp_directory`` settings."""
-        for name, value in _resolve_duckdb_settings().items():
+        settings = _resolve_duckdb_settings()
+        for name, value in settings.items():
             literal = value if isinstance(value, int) else "'" + str(value).replace("'", "''") + "'"
             self._conn.execute(f"SET {name}={literal}")  # noqa: S608 - name is a fixed literal, value sanitized
-        logger.debug("Configured DuckDB connection: %s", _resolve_duckdb_settings())
+        logger.debug("Configured DuckDB connection: %s", settings)
 
     def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
         """

--- a/src/linkml_map/utils/lookup_index.py
+++ b/src/linkml_map/utils/lookup_index.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -10,8 +13,90 @@ import duckdb
 
 from linkml_map.loaders.data_loaders import FileFormat
 
+logger = logging.getLogger(__name__)
+
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _HAS_DIGIT_RE = re.compile(r"[0-9]")
+
+# DuckDB sizes its memory_limit (~80% of RAM) and thread pool from the *physical
+# host*, ignoring container cgroup limits. In a memory-capped container that lets
+# it allocate past the cap, so the kernel OOM-killer SIGKILLs the process (an
+# exit-less crash, no traceback) or it thrashes into a apparent hang. We detect
+# the cgroup limit and configure DuckDB to respect it, turning a silent OOM-kill
+# into a catchable OutOfMemoryException. See join-performance investigation.
+_MEMORY_FRACTION = 0.8  # leave headroom for the Python process / OS
+_CGROUP_V2_MEMORY = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_MEMORY = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_CGROUP_UNLIMITED = 1 << 62  # cgroup v1 "unlimited" sentinel is a near-max int
+_MEMORY_LIMIT_RE = re.compile(r"^\d+(\.\d+)?\s*([KMGT]i?B|%)?$", re.IGNORECASE)
+
+_ENV_MEMORY_LIMIT = "LINKML_MAP_DUCKDB_MEMORY_LIMIT"
+_ENV_THREADS = "LINKML_MAP_DUCKDB_THREADS"
+_ENV_TEMP_DIR = "LINKML_MAP_DUCKDB_TEMP_DIR"
+
+
+def _detect_cgroup_memory_bytes(paths: tuple[str, ...] = (_CGROUP_V2_MEMORY, _CGROUP_V1_MEMORY)) -> int | None:
+    """Return the container memory limit in bytes, or ``None`` if unlimited/undetectable.
+
+    Reads the cgroup v2 (``memory.max``) then v1 (``memory.limit_in_bytes``)
+    interfaces. A literal ``max`` (v2) or near-max sentinel (v1) means no limit.
+
+    :param paths: cgroup interface files to try, in order. Parameterized for testing.
+    """
+    for path in paths:
+        try:
+            raw = Path(path).read_text().strip()
+        except OSError:
+            continue
+        if raw == "max":
+            return None
+        value = int(raw)
+        if value >= _CGROUP_UNLIMITED:
+            return None
+        return value
+    return None
+
+
+def _resolve_duckdb_settings() -> dict[str, str | int]:
+    """Resolve DuckDB connection settings honoring the container and env overrides.
+
+    Precedence for each setting: explicit ``LINKML_MAP_DUCKDB_*`` env var, then a
+    value derived from the cgroup limit, then DuckDB's own default (omitted here).
+
+    - ``memory_limit``: ``_MEMORY_FRACTION`` of the detected cgroup limit, leaving
+      headroom for the rest of the process. Omitted when no limit is detected.
+    - ``threads``: the CPU affinity count (respects cpuset), so we don't spin a
+      host-sized thread pool on a few container vCPUs.
+    - ``temp_directory``: a concrete writable path so spillable operators have
+      somewhere to go (DuckDB's default can be a relative path).
+
+    :returns: Mapping of DuckDB setting name to value, ready to ``SET``.
+    """
+    settings: dict[str, str | int] = {}
+
+    memory_limit = os.environ.get(_ENV_MEMORY_LIMIT)
+    if not memory_limit:
+        cgroup_bytes = _detect_cgroup_memory_bytes()
+        if cgroup_bytes:
+            budget_mib = int(cgroup_bytes * _MEMORY_FRACTION) // (1024 * 1024)
+            memory_limit = f"{budget_mib}MiB"
+    if memory_limit:
+        if not _MEMORY_LIMIT_RE.match(memory_limit.strip()):
+            msg = f"Invalid DuckDB memory limit {memory_limit!r} (expected e.g. '2GB', '512MiB', '80%')"
+            raise ValueError(msg)
+        settings["memory_limit"] = memory_limit.strip()
+
+    threads = os.environ.get(_ENV_THREADS)
+    if threads:
+        settings["threads"] = int(threads)
+    elif hasattr(os, "sched_getaffinity"):
+        settings["threads"] = len(os.sched_getaffinity(0))
+    elif os.cpu_count():
+        settings["threads"] = os.cpu_count()
+
+    settings["temp_directory"] = os.environ.get(_ENV_TEMP_DIR) or tempfile.gettempdir()
+
+    return settings
 
 
 def _parse_numeric(value: str) -> int | float | str:
@@ -69,9 +154,22 @@ class LookupIndex:
     """
 
     def __init__(self) -> None:
-        """Initialize an empty lookup index with an in-memory DuckDB connection."""
+        """Initialize an empty lookup index with an in-memory DuckDB connection.
+
+        The connection is configured to respect container cgroup limits (memory
+        and CPU) rather than DuckDB's host-derived defaults, so a memory-capped
+        container fails with a catchable error instead of being OOM-killed.
+        """
         self._conn = duckdb.connect(":memory:")
+        self._configure_connection()
         self._tables: dict[str, str] = {}  # table_name -> key_column
+
+    def _configure_connection(self) -> None:
+        """Apply container-aware ``memory_limit``/``threads``/``temp_directory`` settings."""
+        for name, value in _resolve_duckdb_settings().items():
+            literal = value if isinstance(value, int) else "'" + str(value).replace("'", "''") + "'"
+            self._conn.execute(f"SET {name}={literal}")  # noqa: S608 - name is a fixed literal, value sanitized
+        logger.debug("Configured DuckDB connection: %s", _resolve_duckdb_settings())
 
     def register_table(self, name: str, file_path: Path | str, key_column: str) -> None:
         """

--- a/tests/test_utils/test_lookup_index_resource_limits.py
+++ b/tests/test_utils/test_lookup_index_resource_limits.py
@@ -1,0 +1,113 @@
+"""Tests for container-aware DuckDB resource configuration on LookupIndex.
+
+DuckDB sizes memory_limit/threads from the physical host and ignores cgroup
+limits, which lets a memory-capped container be OOM-killed (an exit-less crash)
+instead of failing with a catchable error. LookupIndex configures the connection
+to respect the container; these tests verify that wiring.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from linkml_map.utils.lookup_index import (
+    _CGROUP_UNLIMITED,
+    _ENV_MEMORY_LIMIT,
+    _ENV_THREADS,
+    LookupIndex,
+    _detect_cgroup_memory_bytes,
+    _resolve_duckdb_settings,
+)
+
+
+def _current_setting(index: LookupIndex, name: str) -> str:
+    return index._conn.execute(f"SELECT current_setting('{name}')").fetchone()[0]
+
+
+# --- cgroup detection ---
+
+
+def test_detect_cgroup_v2_limit(tmp_path):
+    """A numeric cgroup v2 memory.max is parsed to bytes."""
+    f = tmp_path / "memory.max"
+    f.write_text("4294967296\n")  # 4 GiB
+    assert _detect_cgroup_memory_bytes((str(f),)) == 4294967296
+
+
+def test_detect_cgroup_v2_unlimited(tmp_path):
+    """A literal 'max' means no limit."""
+    f = tmp_path / "memory.max"
+    f.write_text("max\n")
+    assert _detect_cgroup_memory_bytes((str(f),)) is None
+
+
+def test_detect_cgroup_v1_unlimited_sentinel(tmp_path):
+    """A near-max v1 sentinel is treated as unlimited, not a real limit."""
+    f = tmp_path / "memory.limit_in_bytes"
+    f.write_text(f"{_CGROUP_UNLIMITED + 4096}\n")
+    assert _detect_cgroup_memory_bytes((str(f),)) is None
+
+
+def test_detect_cgroup_missing_files_returns_none(tmp_path):
+    """No readable cgroup file (e.g. local dev) yields None rather than raising."""
+    assert _detect_cgroup_memory_bytes((str(tmp_path / "nope"),)) is None
+
+
+def test_detect_cgroup_prefers_first_present(tmp_path):
+    """The first readable path wins (v2 before v1)."""
+    v2 = tmp_path / "memory.max"
+    v2.write_text("2147483648")  # 2 GiB
+    v1 = tmp_path / "memory.limit_in_bytes"
+    v1.write_text("1073741824")  # 1 GiB
+    assert _detect_cgroup_memory_bytes((str(v2), str(v1))) == 2147483648
+
+
+# --- settings resolution ---
+
+
+def test_env_memory_limit_overrides(monkeypatch):
+    """An explicit env memory limit is honored verbatim."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "1500MiB")
+    assert _resolve_duckdb_settings()["memory_limit"] == "1500MiB"
+
+
+def test_env_threads_overrides(monkeypatch):
+    """An explicit env thread count is honored and coerced to int."""
+    monkeypatch.setenv(_ENV_THREADS, "3")
+    assert _resolve_duckdb_settings()["threads"] == 3
+
+
+def test_invalid_memory_limit_raises(monkeypatch):
+    """A malformed memory limit fails fast rather than reaching DuckDB."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "lots of ram")
+    with pytest.raises(ValueError, match="Invalid DuckDB memory limit"):
+        _resolve_duckdb_settings()
+
+
+def test_threads_default_to_affinity(monkeypatch):
+    """Without an override, threads default to the CPU affinity count (respects cpuset)."""
+    monkeypatch.delenv(_ENV_THREADS, raising=False)
+    expected = len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else os.cpu_count()
+    assert _resolve_duckdb_settings()["threads"] == expected
+
+
+def test_temp_directory_always_set(monkeypatch):
+    """A concrete temp_directory is always provided so spilling has a target."""
+    monkeypatch.delenv("LINKML_MAP_DUCKDB_TEMP_DIR", raising=False)
+    assert _resolve_duckdb_settings()["temp_directory"]
+
+
+# --- end-to-end: settings actually land on the connection ---
+
+
+def test_connection_applies_env_settings(monkeypatch):
+    """Constructing a LookupIndex applies env-configured settings to the live connection."""
+    monkeypatch.setenv(_ENV_MEMORY_LIMIT, "512MiB")
+    monkeypatch.setenv(_ENV_THREADS, "2")
+    with LookupIndex() as index:
+        assert int(_current_setting(index, "threads")) == 2
+        # DuckDB echoes memory_limit as a human string (e.g. "512.0 MiB"); assert it
+        # reflects our 512MiB request rather than the multi-GiB host default.
+        assert "512" in str(_current_setting(index, "memory_limit"))

--- a/tests/test_utils/test_lookup_index_resource_limits.py
+++ b/tests/test_utils/test_lookup_index_resource_limits.py
@@ -129,6 +129,12 @@ def test_temp_directory_always_set(monkeypatch):
     assert _resolve_duckdb_settings()["temp_directory"]
 
 
+def test_temp_directory_whitespace_override_falls_back(monkeypatch):
+    """A whitespace-only override is ignored in favor of the system temp dir."""
+    monkeypatch.setenv(_ENV_TEMP_DIR, "   ")
+    assert _resolve_duckdb_settings()["temp_directory"].strip()
+
+
 # --- end-to-end: settings actually land on the connection ---
 
 

--- a/tests/test_utils/test_lookup_index_resource_limits.py
+++ b/tests/test_utils/test_lookup_index_resource_limits.py
@@ -95,6 +95,27 @@ def test_invalid_threads_raises(monkeypatch, bad):
         _resolve_duckdb_settings()
 
 
+def test_memory_limit_derived_from_cgroup(monkeypatch):
+    """Without an env override, memory_limit is _MEMORY_FRACTION of the cgroup limit, in MiB."""
+    monkeypatch.delenv(_ENV_MEMORY_LIMIT, raising=False)
+    monkeypatch.setattr(
+        "linkml_map.utils.lookup_index._detect_cgroup_memory_bytes",
+        lambda: 4 * 1024 * 1024 * 1024,  # 4 GiB
+    )
+    # 4096 MiB * 0.8 = 3276 MiB (truncated)
+    assert _resolve_duckdb_settings()["memory_limit"] == "3276MiB"
+
+
+def test_memory_limit_derived_clamped_to_1mib(monkeypatch):
+    """A tiny cgroup limit that truncates to 0 MiB is clamped up to a valid 1MiB."""
+    monkeypatch.delenv(_ENV_MEMORY_LIMIT, raising=False)
+    monkeypatch.setattr(
+        "linkml_map.utils.lookup_index._detect_cgroup_memory_bytes",
+        lambda: 1000,  # 1000 bytes * 0.8 // 1 MiB == 0
+    )
+    assert _resolve_duckdb_settings()["memory_limit"] == "1MiB"
+
+
 def test_threads_default_to_affinity(monkeypatch):
     """Without an override, threads default to the CPU affinity count (respects cpuset)."""
     monkeypatch.delenv(_ENV_THREADS, raising=False)

--- a/tests/test_utils/test_lookup_index_resource_limits.py
+++ b/tests/test_utils/test_lookup_index_resource_limits.py
@@ -15,6 +15,7 @@ import pytest
 from linkml_map.utils.lookup_index import (
     _CGROUP_UNLIMITED,
     _ENV_MEMORY_LIMIT,
+    _ENV_TEMP_DIR,
     _ENV_THREADS,
     LookupIndex,
     _detect_cgroup_memory_bytes,
@@ -86,6 +87,14 @@ def test_invalid_memory_limit_raises(monkeypatch):
         _resolve_duckdb_settings()
 
 
+@pytest.mark.parametrize("bad", ["lots", "0", "-2"])
+def test_invalid_threads_raises(monkeypatch, bad):
+    """A non-positive or non-integer thread count fails fast with a clear error."""
+    monkeypatch.setenv(_ENV_THREADS, bad)
+    with pytest.raises(ValueError, match="Invalid DuckDB thread count"):
+        _resolve_duckdb_settings()
+
+
 def test_threads_default_to_affinity(monkeypatch):
     """Without an override, threads default to the CPU affinity count (respects cpuset)."""
     monkeypatch.delenv(_ENV_THREADS, raising=False)
@@ -95,7 +104,7 @@ def test_threads_default_to_affinity(monkeypatch):
 
 def test_temp_directory_always_set(monkeypatch):
     """A concrete temp_directory is always provided so spilling has a target."""
-    monkeypatch.delenv("LINKML_MAP_DUCKDB_TEMP_DIR", raising=False)
+    monkeypatch.delenv(_ENV_TEMP_DIR, raising=False)
     assert _resolve_duckdb_settings()["temp_directory"]
 
 


### PR DESCRIPTION
Standalone container-memory fix, extracted from #273 (whose join-mechanism work is being replaced — see below).

DuckDB sizes `memory_limit` (~80% of RAM) and its thread pool from the **physical host**, ignoring container cgroup limits. In a memory-capped container it allocates past the cap, so the OOM-killer SIGKILLs the process (exit-less crash, no traceback) or it thrashes.

`LookupIndex` now detects the cgroup memory limit and sets `memory_limit`, `threads`, and a concrete `temp_directory` on the connection, with `LINKML_MAP_DUCKDB_*` env overrides. An over-large load now raises a catchable `OutOfMemoryException` instead of being OOM-killed.

Tests: `test_lookup_index_resource_limits.py` (cgroup detection, env overrides, settings applied to the live connection). Full suite green (966 passed).

Context: #273's lazy join machinery is a dead end — downstream validation showed the point-lookup design can't do to-many joins (`LIMIT 1`) and silently returns `None` for cross-table references that live only in expressions. That work is being replaced by a real DuckDB-join engine in a separate effort. This PR keeps the one piece worth landing on its own.