### PR TITLE
Synthesize implicit joins from expression references

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -267,14 +267,29 @@ def _pre_flight_validate(
     ``tr.target_schemaview`` when set, avoiding a duplicate load of large
     or remote schemas.
     """
-    from linkml_map.validator import validate_spec_semantics
+    from linkml_map.validator import ValidationMessage, validate_spec_semantics
 
     if tr.specification is None:
         return
 
-    spec_dict = tr.specification.model_dump(exclude_none=True)
-
     messages = list(tr.spec_messages)
+
+    # Validate the *derived* spec when a source schema is available, so the
+    # semantic checks observe synthesized joins rather than predicting them.
+    # Synthesis can fail loud (e.g. an un-keyable cross-table reference); surface
+    # that as a finding instead of crashing pre-flight, and fall back to the raw
+    # spec for the remaining checks.
+    spec = tr.specification
+    if tr.source_schemaview is not None:
+        try:
+            derived = tr.derived_specification
+        except ValueError as err:
+            messages.append(ValidationMessage(severity="error", path="", message=str(err)))
+            derived = None
+        if derived is not None:
+            spec = derived
+
+    spec_dict = spec.model_dump(exclude_none=True)
     messages.extend(
         validate_spec_semantics(
             spec_dict,
@@ -306,6 +321,9 @@ def _filter_spec_to_entity(tr: ObjectTransformer, entity: str | None) -> None:
         msg = f"--entity {entity!r} did not match any class_derivation. Available: {names}"
         raise click.ClickException(msg)
     tr.specification.class_derivations = matched
+    # Mutating the spec invalidates any derived spec already computed (e.g. by
+    # pre-flight validation), so it is rebuilt from the filtered spec on next access.
+    tr._derived_specification = None
 
 
 def _emit_spec_to_file(tr: ObjectTransformer, emit_spec: str) -> None:

--- a/src/linkml_map/transformer/object_transformer.py
+++ b/src/linkml_map/transformer/object_transformer.py
@@ -976,22 +976,12 @@ class ObjectTransformer(Transformer):
                     )
                 else:
                     # No join spec for this nested source — cross-table reference can't be resolved.
-                    # Re-derive the candidate set so the diagnostic tells the user *why* synthesis
-                    # failed (no overlap vs. multiple non-identifier candidates), recovering the
-                    # detail lost when the per-row resolution path was consolidated into
-                    # normalization-time synthesis.
-                    from linkml_map.utils.join_utils import find_common_columns
+                    # Re-derive the reason via the shared resolver so the diagnostic tells the user
+                    # *why* synthesis failed (no overlap vs. multiple non-identifier candidates),
+                    # using the same logic synthesis used rather than a parallel implementation.
+                    from linkml_map.utils.join_utils import resolve_join
 
-                    common = find_common_columns(self.source_schemaview, parent_source, nested_source)
-                    if not common:
-                        reason = f"no columns are shared between {parent_source!r} and {nested_source!r}"
-                    else:
-                        candidates = ", ".join(sorted(common))
-                        reason = (
-                            f"multiple candidate join columns are shared between "
-                            f"{parent_source!r} and {nested_source!r} ({candidates}); "
-                            f"specify which to use"
-                        )
+                    reason = resolve_join(self.source_schemaview, parent_source, nested_source).reason
                     raise TransformationError(
                         message=(
                             f"Nested class {cls_derivation.name!r} has "

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -712,15 +712,21 @@ class Transformer(ABC):
         """Fail loud on a qualified ``{Name.col}`` whose root resolves to nothing.
 
         ``Name`` is resolvable when it is a source table, an in-scope source
-        (``available``), a slot on *parent_source* (a same-row or inlined-object
-        reference), or a known expression function. Anything else — a typo or a
-        renamed/missing table — would silently resolve to ``None`` at runtime, so
-        surface it at normalization time instead.
+        (``available``), a declared join alias on *host_cd* (which may differ
+        from its ``class_named`` schema class), a slot on *parent_source* (a
+        same-row or inlined-object reference), or a known expression function.
+        Anything else — a typo or a renamed/missing table — would silently
+        resolve to ``None`` at runtime, so surface it at normalization time.
 
         :raises ValueError: if any qualified root is unresolvable.
         """
         known = (
-            table_names | available | self._source_slot_names(sv, parent_source) | set(FUNCTIONS) | INJECTED_EVAL_NAMES
+            table_names
+            | available
+            | set(host_cd.joins or {})
+            | self._source_slot_names(sv, parent_source)
+            | set(FUNCTIONS)
+            | INJECTED_EVAL_NAMES
         )
         unknown = roots - known
         if unknown:

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -614,6 +614,10 @@ class Transformer(ABC):
         for cd in spec.class_derivations:
             parent_source = cd.populated_from or cd.name
             self._walk_and_synthesize_joins(cd, parent_source, sv, table_names, {parent_source})
+        # Cross-table refs in derivations with no enclosing class_derivation
+        # (top-level enum/permissible-value/slot derivations) have nowhere to host
+        # a join — fail fast rather than silently resolve to None.
+        self._reject_unhostable_cross_table_refs(spec, table_names)
 
     def _walk_and_synthesize_joins(
         self,
@@ -639,9 +643,9 @@ class Transformer(ABC):
         for sd in class_deriv.slot_derivations.values():
             self._synthesize_joins_for_expressions(class_deriv, parent_source, sd, sv, table_names, available)
 
-            if not sd.class_derivations:
-                continue
-            for nested_cd in sd.class_derivations:
+            # object_derivations are flattened into class_derivations at spec-load
+            # time (deprecated), so synthesis only needs to walk class_derivations.
+            for nested_cd in sd.class_derivations or []:
                 nested_source = nested_cd.populated_from or parent_source
                 if nested_source != parent_source:
                     self._synthesize_join(class_deriv, parent_source, nested_source, sv)
@@ -694,6 +698,44 @@ class Transformer(ABC):
             table,
             join_key,
         )
+
+    def _reject_unhostable_cross_table_refs(self, spec: TransformationSpecification, table_names: set[str]) -> None:
+        """Fail fast on a cross-table reference that has no class_derivation to host its join.
+
+        Enum, permissible-value, and top-level slot derivations are not nested
+        under a ClassDerivation, so a ``{Table.col}`` reference in one of them
+        cannot be turned into a ``joins:`` entry. Rather than let it silently
+        resolve to ``None`` at runtime, surface it here.
+
+        :raises ValueError: if such a reference is found.
+        """
+
+        def check(kind: str, name: str | None, derivation: Any) -> None:  # noqa: ANN401
+            for expression in iter_expressions(derivation):
+                refs = extract_table_references(expression, table_names)
+                if refs:
+                    msg = (
+                        f"Cross-table reference(s) {sorted(refs)} in {kind} {name!r} cannot be "
+                        f"joined: only class_derivations can host joins. Move the derivation under "
+                        f"a class_derivation, or reference only same-row columns."
+                    )
+                    raise ValueError(msg)
+
+        for enum_derivation in self._values(spec.enum_derivations):
+            check("enum_derivation", enum_derivation.name, enum_derivation)
+            for pv_derivation in self._values(enum_derivation.permissible_value_derivations):
+                check("permissible_value_derivation", pv_derivation.name, pv_derivation)
+        for slot_derivation in self._values(spec.slot_derivations):
+            check("top-level slot_derivation", slot_derivation.name, slot_derivation)
+
+    @staticmethod
+    def _values(collection: Any) -> list:  # noqa: ANN401 - dict- or list-form linkml collection
+        """Return the members of a linkml multivalued collection, whether dict- or list-form."""
+        if not collection:
+            return []
+        if hasattr(collection, "values"):
+            return list(collection.values())
+        return list(collection)
 
     def _get_class_derivation(self, target_class_name: str) -> ClassDerivation:
         spec = self.derived_specification

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -26,7 +26,8 @@ from linkml_map.datamodel.transformer_model import (
     TransformationSpecification,
 )
 from linkml_map.inference.inference import induce_missing_values
-from linkml_map.utils.join_utils import pick_join_key
+from linkml_map.utils.expression_locations import extract_table_references, iter_expressions
+from linkml_map.utils.join_utils import infer_join_key
 from linkml_map.utils.schema_patch import apply_schema_patch
 
 logger = logging.getLogger(__name__)
@@ -589,12 +590,17 @@ class Transformer(ABC):
         return self._derived_specification
 
     def _synthesize_implicit_joins(self, spec: TransformationSpecification) -> None:
-        """Add explicit join specs for nested class_derivations with cross-table references.
+        """Add explicit join specs for every implicit cross-table reference.
 
-        Walks all nested class_derivations. When a nested CD has a different
-        ``populated_from`` than its parent and no explicit ``joins:`` block,
-        synthesizes an ``AliasedClass`` join entry on the parent CD using
-        :func:`pick_join_key` to determine the join column.
+        Two kinds of implicit reference are normalized into explicit
+        ``AliasedClass`` joins on the enclosing ClassDerivation (the only place
+        ``joins:`` can live):
+
+        - a nested class_derivation whose ``populated_from`` is a different table;
+        - a ``{Table.col}`` reference in *any* expression on a class derivation or
+          its slot derivations (``expr``, ``expression_mappings``, etc.). This
+          second case was previously unhandled, which is why an expr-only implicit
+          join silently resolved to ``None``.
 
         Mutates *spec* in place.
 
@@ -604,49 +610,90 @@ class Transformer(ABC):
         if sv is None:
             return
 
+        table_names = set(sv.all_classes())
         for cd in spec.class_derivations:
             parent_source = cd.populated_from or cd.name
-            self._walk_and_synthesize_joins(cd, parent_source, sv)
+            self._walk_and_synthesize_joins(cd, parent_source, sv, table_names, {parent_source})
 
     def _walk_and_synthesize_joins(
         self,
         class_deriv: ClassDerivation,
         parent_source: str,
         sv: SchemaView,
+        table_names: set[str],
+        available: set[str],
     ) -> None:
-        """Recursively walk slot_derivations and synthesize joins on parent CDs.
+        """Recursively synthesize joins for cross-table references under *class_deriv*.
 
-        :param class_deriv: The parent ClassDerivation to add joins to.
-        :param parent_source: The parent's populated_from.
+        :param class_deriv: The ClassDerivation that will host synthesized joins.
+        :param parent_source: This derivation's ``populated_from``.
         :param sv: Source schema view.
+        :param table_names: All source-schema class names (table candidates).
+        :param available: Tables already in scope here (the ancestor source chain
+            plus this source) — a reference to one of these is the parent/own row,
+            not a new join.
         """
+        # Expressions on the class derivation itself and on each slot derivation
+        # are hosted on this class derivation.
+        self._synthesize_joins_for_expressions(class_deriv, parent_source, class_deriv, sv, table_names, available)
         for sd in class_deriv.slot_derivations.values():
+            self._synthesize_joins_for_expressions(class_deriv, parent_source, sd, sv, table_names, available)
+
             if not sd.class_derivations:
                 continue
             for nested_cd in sd.class_derivations:
                 nested_source = nested_cd.populated_from or parent_source
-
-                # Synthesize a join when the nested CD references a different table
                 if nested_source != parent_source:
-                    join_key = pick_join_key(sv, parent_source, nested_source)
-                    if join_key is not None:
-                        if class_deriv.joins is None:
-                            class_deriv.joins = {}
-                        if nested_source not in class_deriv.joins:
-                            class_deriv.joins[nested_source] = AliasedClass(
-                                alias=nested_source,
-                                join_on=join_key,
-                            )
-                            logger.info(
-                                "Synthesized implicit join: %s.joins[%r] on column %r",
-                                class_deriv.name,
-                                nested_source,
-                                join_key,
-                            )
-
-                # Always recurse into nested CD's own slots
+                    self._synthesize_join(class_deriv, parent_source, nested_source, sv)
                 if nested_cd.slot_derivations:
-                    self._walk_and_synthesize_joins(nested_cd, nested_source, sv)
+                    self._walk_and_synthesize_joins(
+                        nested_cd, nested_source, sv, table_names, available | {nested_source}
+                    )
+
+    def _synthesize_joins_for_expressions(
+        self,
+        host_cd: ClassDerivation,
+        parent_source: str,
+        derivation: Any,
+        sv: SchemaView,
+        table_names: set[str],
+        available: set[str],
+    ) -> None:
+        """Synthesize joins on *host_cd* for every ``{Table.col}`` in *derivation*'s expressions.
+
+        Tables already in scope (``available``) are the parent/own row and need no join.
+        """
+        for expression in iter_expressions(derivation):
+            for table in extract_table_references(expression, table_names):
+                if table not in available:
+                    self._synthesize_join(host_cd, parent_source, table, sv)
+
+    def _synthesize_join(
+        self,
+        class_deriv: ClassDerivation,
+        parent_source: str,
+        table: str,
+        sv: SchemaView,
+    ) -> None:
+        """Add an explicit ``AliasedClass`` join for *table* on *class_deriv*, if it can be keyed.
+
+        No-op when the join is already declared/synthesized, or when no join key
+        can be inferred (left for an explicit ``joins:`` block — unchanged behavior).
+        """
+        if class_deriv.joins and table in class_deriv.joins:
+            return
+        join_key = infer_join_key(sv, parent_source, table)
+        if join_key is None:
+            return
+        if class_deriv.joins is None:
+            class_deriv.joins = {}
+        class_deriv.joins[table] = AliasedClass(alias=table, join_on=join_key)
+        logger.info(
+            "Synthesized implicit join: %s.joins[%r] on column %r",
+            class_deriv.name,
+            table,
+            join_key,
+        )
 
     def _get_class_derivation(self, target_class_name: str) -> ClassDerivation:
         spec = self.derived_specification

--- a/src/linkml_map/transformer/transformer.py
+++ b/src/linkml_map/transformer/transformer.py
@@ -26,7 +26,12 @@ from linkml_map.datamodel.transformer_model import (
     TransformationSpecification,
 )
 from linkml_map.inference.inference import induce_missing_values
-from linkml_map.utils.expression_locations import extract_table_references, iter_expressions
+from linkml_map.utils.eval_utils import FUNCTIONS, INJECTED_EVAL_NAMES
+from linkml_map.utils.expression_locations import (
+    extract_braced_reference_roots,
+    extract_table_references,
+    iter_expressions,
+)
 from linkml_map.utils.join_utils import infer_join_key
 from linkml_map.utils.schema_patch import apply_schema_patch
 
@@ -599,9 +604,13 @@ class Transformer(ABC):
             if self.specification is None:
                 return None
             self._apply_source_schema_patches()
-            self._derived_specification = deepcopy(self.specification)
-            induce_missing_values(self._derived_specification, self.source_schemaview)
-            self._synthesize_implicit_joins(self._derived_specification)
+            # Build into a local and only cache on full success: synthesis can
+            # fail loud (e.g. an un-keyable cross-table reference), and caching a
+            # half-synthesized spec would poison every later access.
+            derived = deepcopy(self.specification)
+            induce_missing_values(derived, self.source_schemaview)
+            self._synthesize_implicit_joins(derived)
+            self._derived_specification = derived
         return self._derived_specification
 
     def _synthesize_implicit_joins(self, spec: TransformationSpecification) -> None:
@@ -681,11 +690,53 @@ class Transformer(ABC):
         """Synthesize joins on *host_cd* for every ``{Table.col}`` in *derivation*'s expressions.
 
         Tables already in scope (``available``) are the parent/own row and need no join.
+        A qualified ``{Name.col}`` whose root is neither a table, an in-scope source, a
+        slot on this source, nor a function is an unresolvable reference and fails loud.
         """
         for expression in iter_expressions(derivation):
             for table in extract_table_references(expression, table_names):
                 if table not in available:
-                    self._synthesize_join(host_cd, parent_source, table, sv)
+                    self._synthesize_join(host_cd, parent_source, table, sv, required=True)
+            roots = extract_braced_reference_roots(expression)
+            self._reject_unknown_qualified_roots(host_cd, parent_source, roots, sv, table_names, available)
+
+    def _reject_unknown_qualified_roots(
+        self,
+        host_cd: ClassDerivation,
+        parent_source: str,
+        roots: set[str],
+        sv: SchemaView,
+        table_names: set[str],
+        available: set[str],
+    ) -> None:
+        """Fail loud on a qualified ``{Name.col}`` whose root resolves to nothing.
+
+        ``Name`` is resolvable when it is a source table, an in-scope source
+        (``available``), a slot on *parent_source* (a same-row or inlined-object
+        reference), or a known expression function. Anything else — a typo or a
+        renamed/missing table — would silently resolve to ``None`` at runtime, so
+        surface it at normalization time instead.
+
+        :raises ValueError: if any qualified root is unresolvable.
+        """
+        known = (
+            table_names | available | self._source_slot_names(sv, parent_source) | set(FUNCTIONS) | INJECTED_EVAL_NAMES
+        )
+        unknown = roots - known
+        if unknown:
+            msg = (
+                f"Expression reference(s) {sorted(unknown)} on class_derivation {host_cd.name!r} "
+                f"cannot be resolved: each root must be a source table, a slot on {parent_source!r}, "
+                f"or a function. Fix the reference or correct the source schema."
+            )
+            raise ValueError(msg)
+
+    @staticmethod
+    def _source_slot_names(sv: SchemaView, source: str) -> set[str]:
+        """Return the induced slot names of *source*, or empty if it is not a class."""
+        if source not in sv.all_classes():
+            return set()
+        return {s.name for s in sv.class_induced_slots(source)}
 
     def _synthesize_join(
         self,
@@ -693,16 +744,35 @@ class Transformer(ABC):
         parent_source: str,
         table: str,
         sv: SchemaView,
+        *,
+        required: bool = False,
     ) -> None:
-        """Add an explicit ``AliasedClass`` join for *table* on *class_deriv*, if it can be keyed.
+        """Add an explicit ``AliasedClass`` join for *table* on *class_deriv*.
 
-        No-op when the join is already declared/synthesized, or when no join key
-        can be inferred (left for an explicit ``joins:`` block — unchanged behavior).
+        No-op when the join is already declared/synthesized. When no join key can
+        be inferred, behavior depends on *required*:
+
+        - ``required=True`` (an expression ``{table.col}`` reference): fail loud.
+          An expression reference has no runtime safety net — it silently
+          resolves to ``None`` — so an un-keyable one must surface here.
+        - ``required=False`` (a structural ``populated_from`` join): return
+          quietly. The engine reports an un-keyable structural join loudly at
+          runtime with a more specific diagnostic (shared/candidate columns).
+
+        :param required: whether an un-keyable reference is a hard error.
+        :raises ValueError: if *required* and *table* cannot be keyed.
         """
         if class_deriv.joins and table in class_deriv.joins:
             return
         join_key = infer_join_key(sv, parent_source, table)
         if join_key is None:
+            if required:
+                msg = (
+                    f"Cross-table reference to {table!r} from {parent_source!r} on class_derivation "
+                    f"{class_deriv.name!r} cannot be joined: no shared join key could be inferred. "
+                    f"Declare an explicit 'joins:' entry with 'join_on' (or 'source_key'/'lookup_key')."
+                )
+                raise ValueError(msg)
             return
         if class_deriv.joins is None:
             class_deriv.joins = {}

--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -659,10 +659,10 @@ class LinkMLEvaluator(EvalWithCompoundTypes):
                 # warn-and-null override in ``_eval_name``.
                 obj = super()._eval_name(node.value)
             except NameNotDefined:
+                ref = f"{node.value.id}.{node.attr}"
                 msg = (
-                    f"Expression references unknown {node.value.id!r} in "
-                    f"{node.value.id + '.' + node.attr!r}: no such source class, join, or slot. "
-                    f"Typo or stale reference?"
+                    f"Expression references unknown {node.value.id!r} in {ref!r}: "
+                    f"no such source class, join, or slot. Typo or stale reference?"
                 )
                 raise NameError(msg) from None
         else:

--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -394,6 +394,13 @@ FUNCTIONS: dict[str, Any] = {
     "is_numeric": _is_numeric,
 }
 
+#: Names injected into the unrestricted-eval namespace by ``ObjectTransformer``
+#: that are neither source slots nor tables. The restricted evaluator does not
+#: bind them, so a qualified ``{src.x}`` must not be flagged as an unknown
+#: reference — it resolves in the unrestricted fallback (or warns/nulls in
+#: restricted mode). Shared with normalization-time reference checking.
+INJECTED_EVAL_NAMES: frozenset[str] = frozenset({"src", "target", "uuid5"})
+
 
 def _maybe_coerce_numeric(left: Any, right: Any) -> tuple[Any, Any]:  # noqa: ANN401
     """
@@ -637,8 +644,29 @@ class LinkMLEvaluator(EvalWithCompoundTypes):
 
         If the object is a list, ``obj.attr`` returns ``[item.attr for item in obj]``.
         If the object is a dict, it distributes over values.
+
+        A qualified reference ``{Name.attr}`` whose *root* name is genuinely
+        unknown (no such source slot, join alias, or function) is a broken
+        reference — a typo or a missing/renamed table — and fails loud even in
+        non-strict mode. This is distinct from a *bare* ``{col}`` absent from a
+        row (legitimate SQL null) and from a root that resolves to ``None`` (a
+        sparse-join miss or an absent schema slot), both of which stay null.
         """
-        obj = self._eval(node.value)
+        if isinstance(node.value, ast.Name) and node.value.id not in INJECTED_EVAL_NAMES:
+            try:
+                # Resolve the root via the base evaluator so an unknown name
+                # surfaces as NameNotDefined instead of being swallowed by the
+                # warn-and-null override in ``_eval_name``.
+                obj = super()._eval_name(node.value)
+            except NameNotDefined:
+                msg = (
+                    f"Expression references unknown {node.value.id!r} in "
+                    f"{node.value.id + '.' + node.attr!r}: no such source class, join, or slot. "
+                    f"Typo or stale reference?"
+                )
+                raise NameError(msg) from None
+        else:
+            obj = self._eval(node.value)
         return _distributed_getattr(obj, node.attr)
 
 

--- a/src/linkml_map/utils/expression_locations.py
+++ b/src/linkml_map/utils/expression_locations.py
@@ -13,7 +13,8 @@ so the normalizer can never silently miss a join again.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import ast
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 #: Fields whose value *is* an expression string (model range: ``string``).
@@ -55,3 +56,29 @@ def iter_expressions(derivation: Any) -> Iterator[str]:  # noqa: ANN401 - any *D
                 entry_value = getattr(entry, "value", None)
                 if entry_value:
                     yield entry_value
+
+
+def extract_table_references(expression: str, table_names: Iterable[str]) -> set[str]:
+    """Return the tables referenced as ``{Table.col}`` in an expression.
+
+    The LinkML expression language is parsed with Python's ``ast``, so
+    ``{Table.col}`` appears as attribute access ``Table.col``. A reference counts
+    only when the attribute's root is a bare name matching a known table (a
+    source-schema class); bare column names (``{col}``) and attribute access on
+    non-tables are ignored. Parsing uses ``exec`` mode because the expression
+    language permits statements (assignments, comprehensions) that ``eval`` mode
+    rejects.
+
+    :param expression: a LinkML expression string.
+    :param table_names: names that denote tables (source-schema classes).
+    :returns: the set of referenced table names.
+    :raises SyntaxError: if *expression* is not parseable (a malformed expr that
+        would also fail at evaluation — surfaced here rather than masked).
+    """
+    tables = set(table_names)
+    refs: set[str] = set()
+    tree = ast.parse(expression, mode="exec")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id in tables:
+            refs.add(node.value.id)
+    return refs

--- a/src/linkml_map/utils/expression_locations.py
+++ b/src/linkml_map/utils/expression_locations.py
@@ -1,0 +1,57 @@
+"""Single source of truth for where expressions live in a transformation spec.
+
+Cross-table references (``{Table.col}``) can appear in *any* expression, not
+just ``SlotDerivation.expr`` — also enum/permissible-value ``expr`` and the
+``expression*`` mapping tables inherited from ``ElementDerivation``. The join
+normalizer must scan every one of these to synthesize the implicit joins they
+imply, so this module enumerates them in one place.
+
+The companion completeness-guard test introspects the transformer model and
+fails if a new expression-bearing field is added without being registered here,
+so the normalizer can never silently miss a join again.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+#: Fields whose value *is* an expression string (model range: ``string``).
+#: Present on SlotDerivation, EnumDerivation, and PermissibleValueDerivation.
+SELF_EXPR_FIELDS: tuple[str, ...] = ("expr",)
+
+#: ``KeyVal`` mapping fields (inherited from ElementDerivation) and where the
+#: expression(s) live within each entry:
+#: ``"keys"`` — the mapping key is a (boolean) expression;
+#: ``"values"`` — the entry value is an expression;
+#: ``"both"`` — key and value are expressions.
+MAPPING_EXPR_FIELDS: dict[str, str] = {
+    "expression_mappings": "values",
+    "expression_to_value_mappings": "keys",
+    "expression_to_expression_mappings": "both",
+}
+
+
+def iter_expressions(derivation: Any) -> Iterator[str]:  # noqa: ANN401 - any *Derivation pydantic object
+    """Yield every expression string carried directly by *derivation*.
+
+    Covers ``expr`` and the ``expression*`` mapping fields. Does **not** recurse
+    into nested derivations — callers walk the derivation tree and call this per
+    node. Empty/absent fields yield nothing.
+
+    :param derivation: a ``*Derivation`` object (Class/Slot/Enum/PermissibleValue).
+    :yields: each non-empty expression string the derivation declares.
+    """
+    for field in SELF_EXPR_FIELDS:
+        value = getattr(derivation, field, None)
+        if value:
+            yield value
+    for field, where in MAPPING_EXPR_FIELDS.items():
+        mapping = getattr(derivation, field, None) or {}
+        for key, entry in mapping.items():
+            if where in ("keys", "both") and key:
+                yield key
+            if where in ("values", "both"):
+                entry_value = getattr(entry, "value", None)
+                if entry_value:
+                    yield entry_value

--- a/src/linkml_map/utils/expression_locations.py
+++ b/src/linkml_map/utils/expression_locations.py
@@ -58,6 +58,33 @@ def iter_expressions(derivation: Any) -> Iterator[str]:  # noqa: ANN401 - any *D
                     yield entry_value
 
 
+def extract_braced_reference_roots(expression: str) -> set[str]:
+    """Return the bare-name roots of braced ``{Name.attr}`` references.
+
+    Only braced references (``ast.Set`` single-element displays — the LinkML
+    expression reference syntax, mirroring ``_eval_set``) are inspected, so
+    lambda parameters, comprehension targets, and raw-Python attribute access in
+    unrestricted expressions are *not* treated as references. Each braced
+    ``{x.y}`` contributes its root ``x``; a bare ``{col}`` contributes nothing.
+
+    Used to spot a reference whose root is neither a known table, an in-scope
+    source, a source slot, nor a function — an unresolvable ``{Unknown.col}``
+    that would otherwise silently null at runtime.
+
+    :param expression: a LinkML expression string.
+    :returns: the set of braced-reference attribute roots.
+    :raises SyntaxError: if *expression* is not parseable.
+    """
+    roots: set[str] = set()
+    tree = ast.parse(expression, mode="exec")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Set):
+            for elt in node.elts:
+                if isinstance(elt, ast.Attribute) and isinstance(elt.value, ast.Name):
+                    roots.add(elt.value.id)
+    return roots
+
+
 def extract_table_references(expression: str, table_names: Iterable[str]) -> set[str]:
     """Return the tables referenced as ``{Table.col}`` in an expression.
 

--- a/src/linkml_map/utils/join_utils.py
+++ b/src/linkml_map/utils/join_utils.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from linkml_runtime import SchemaView
 
+#: Consistently-named subject-id columns preferred as the join key when present
+#: in both tables, before the structural heuristic. Real dbGaP joins are
+#: subject-keyed, and the subject id (``dbGaP_Subject_ID``) is named consistently
+#: across prepared tables even when other identifier columns differ. Overridable
+#: by a future key registry.
+SUBJECT_KEY_CANDIDATES: tuple[str, ...] = ("dbGaP_Subject_ID",)
+
 
 def _is_identifier_in_either(sv: SchemaView, col: str, class_a: str, class_b: str) -> bool:
     """Check if a column is an identifier in either of two classes.
@@ -62,3 +69,30 @@ def pick_join_key(sv: SchemaView, class_a: str, class_b: str) -> str | None:
         return next(iter(common))
     # Multiple non-id common columns — can't pick automatically
     return None
+
+
+def infer_join_key(
+    sv: SchemaView,
+    class_a: str,
+    class_b: str,
+    subject_keys: tuple[str, ...] = SUBJECT_KEY_CANDIDATES,
+) -> str | None:
+    """Infer the join key between two source classes.
+
+    Prefers a consistently-named subject-id column (:data:`SUBJECT_KEY_CANDIDATES`)
+    present in both classes — real dbGaP joins are subject-keyed, and the subject
+    id is named consistently even when other identifier columns differ across
+    tables, which the structural heuristic cannot match. Falls back to
+    :func:`pick_join_key`.
+
+    :param sv: Source schema view.
+    :param class_a: First source class name.
+    :param class_b: Second source class name.
+    :param subject_keys: Preferred subject-id column names, in order.
+    :returns: The join key column name, or None if none can be determined.
+    """
+    common = find_common_columns(sv, class_a, class_b)
+    for candidate in subject_keys:
+        if candidate in common:
+            return candidate
+    return pick_join_key(sv, class_a, class_b)

--- a/src/linkml_map/utils/join_utils.py
+++ b/src/linkml_map/utils/join_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from linkml_runtime import SchemaView
 
 #: Consistently-named subject-id columns preferred as the join key when present
@@ -71,6 +73,62 @@ def pick_join_key(sv: SchemaView, class_a: str, class_b: str) -> str | None:
     return None
 
 
+@dataclass(frozen=True)
+class JoinResolution:
+    """Outcome of resolving an implicit join between two source classes.
+
+    Exactly one of *key*/*reason* is set: a successful resolution carries the
+    join column in *key* (and ``reason is None``); a failure carries a
+    human-readable *reason* (and ``key is None``).
+    """
+
+    key: str | None
+    reason: str | None
+
+
+def resolve_join(
+    sv: SchemaView,
+    class_a: str,
+    class_b: str,
+    subject_keys: tuple[str, ...] = SUBJECT_KEY_CANDIDATES,
+) -> JoinResolution:
+    """Resolve the implicit join key between two source classes, or explain why not.
+
+    Single source of truth for join-key inference. Prefers a consistently-named
+    subject-id column (:data:`SUBJECT_KEY_CANDIDATES`) present in both classes —
+    real dbGaP joins are subject-keyed, and the subject id is named consistently
+    even when other identifier columns differ across tables, which the structural
+    heuristic cannot match. Falls back to :func:`pick_join_key`. When no key can
+    be determined, returns a :class:`JoinResolution` whose *reason* explains
+    whether the classes share no columns or share too many to disambiguate.
+
+    Synthesis, validation, and runtime diagnostics all call this so they agree on
+    both the chosen key and the failure explanation.
+
+    :param sv: Source schema view.
+    :param class_a: First source class name.
+    :param class_b: Second source class name.
+    :param subject_keys: Preferred subject-id column names, in order.
+    :returns: A :class:`JoinResolution` with either *key* or *reason* set.
+    """
+    common = find_common_columns(sv, class_a, class_b)
+    for candidate in subject_keys:
+        if candidate in common:
+            return JoinResolution(key=candidate, reason=None)
+    key = pick_join_key(sv, class_a, class_b)
+    if key is not None:
+        return JoinResolution(key=key, reason=None)
+    if not common:
+        reason = f"no columns are shared between {class_a!r} and {class_b!r}"
+    else:
+        candidates = ", ".join(sorted(common))
+        reason = (
+            f"multiple candidate join columns are shared between {class_a!r} and "
+            f"{class_b!r} ({candidates}); cannot pick automatically"
+        )
+    return JoinResolution(key=None, reason=reason)
+
+
 def infer_join_key(
     sv: SchemaView,
     class_a: str,
@@ -79,11 +137,7 @@ def infer_join_key(
 ) -> str | None:
     """Infer the join key between two source classes.
 
-    Prefers a consistently-named subject-id column (:data:`SUBJECT_KEY_CANDIDATES`)
-    present in both classes — real dbGaP joins are subject-keyed, and the subject
-    id is named consistently even when other identifier columns differ across
-    tables, which the structural heuristic cannot match. Falls back to
-    :func:`pick_join_key`.
+    Thin wrapper over :func:`resolve_join` for callers that only need the key.
 
     :param sv: Source schema view.
     :param class_a: First source class name.
@@ -91,8 +145,4 @@ def infer_join_key(
     :param subject_keys: Preferred subject-id column names, in order.
     :returns: The join key column name, or None if none can be determined.
     """
-    common = find_common_columns(sv, class_a, class_b)
-    for candidate in subject_keys:
-        if candidate in common:
-            return candidate
-    return pick_join_key(sv, class_a, class_b)
+    return resolve_join(sv, class_a, class_b, subject_keys).key

--- a/src/linkml_map/validator.py
+++ b/src/linkml_map/validator.py
@@ -34,7 +34,7 @@ from linkml_runtime import SchemaView
 from linkml_map.datamodel import TR_SCHEMA
 from linkml_map.transformer.transformer import Transformer
 from linkml_map.utils.eval_utils import FUNCTIONS
-from linkml_map.utils.join_utils import find_common_columns, pick_join_key
+from linkml_map.utils.join_utils import resolve_join
 
 logger = logging.getLogger(__name__)
 
@@ -918,11 +918,15 @@ def _check_cross_table_join(
     Closes #211 at validate-spec time. Mirrors the runtime synthesis logic
     in :class:`~linkml_map.transformer.transformer.Transformer`:
 
-    - Explicit ``joins:`` covers the nested source → no message.
-    - No explicit join, :func:`~linkml_map.utils.join_utils.pick_join_key`
-      returns a column → ``info`` (#212 will auto-synthesize at runtime).
-    - No explicit join, no implicit join can be synthesized → ``warning``
-      with the same diagnostic the runtime would raise.
+    - Explicit ``joins:`` covers the nested source → verify its keys.
+    - No explicit join, :func:`~linkml_map.utils.join_utils.resolve_join`
+      returns a key → ``info`` (will auto-synthesize at runtime).
+    - No explicit join, :func:`~linkml_map.utils.join_utils.resolve_join`
+      returns a reason → ``warning`` with the same diagnostic the runtime
+      would raise.
+
+    When run against the *derived* spec (post-synthesis), synthesized joins are
+    already explicit, so the first branch handles them and no prediction occurs.
     """
     nested_source = nested_cd.get("populated_from")
     # Identity case for the parent: fall back to its name when populated_from
@@ -994,8 +998,8 @@ def _check_cross_table_join(
         # Missing-class errors are emitted elsewhere; can't predict joinability.
         return
 
-    key = pick_join_key(source_sv, parent_source, nested_source)
-    if key is not None:
+    resolution = resolve_join(source_sv, parent_source, nested_source)
+    if resolution.key is not None:
         messages.append(
             ValidationMessage(
                 severity="info",
@@ -1004,21 +1008,13 @@ def _check_cross_table_join(
                     f"Nested 'populated_from={nested_source}' differs from parent "
                     f"'populated_from={parent_source}'. No explicit join entry for "
                     f"'{nested_source}'; implicit join will be synthesized on column "
-                    f"'{key}'. Consider declaring the join explicitly."
+                    f"'{resolution.key}'. Consider declaring the join explicitly."
                 ),
             )
         )
         return
 
-    common = find_common_columns(source_sv, parent_source, nested_source)
-    if not common:
-        reason = f"no columns are shared between '{parent_source}' and '{nested_source}'"
-    else:
-        candidates = ", ".join(f"'{c}'" for c in sorted(common))
-        reason = (
-            f"multiple candidate join columns are shared between '{parent_source}' "
-            f"and '{nested_source}' ({candidates}); cannot pick automatically"
-        )
+    reason = resolution.reason
     messages.append(
         ValidationMessage(
             severity="warning",

--- a/tests/test_transformer/test_expr_implicit_join.py
+++ b/tests/test_transformer/test_expr_implicit_join.py
@@ -1,0 +1,114 @@
+"""Implicit joins synthesized from expression references.
+
+A `{Table.col}` reference inside an `expr:` (with no `joins:` block and no nested
+class_derivation for that table) must synthesize the join — previously it was
+invisible to synthesis and silently resolved to None. This is the dominant real
+pattern (bdc-harmonized-variables: 440 specs, zero `joins:` blocks).
+"""
+
+from __future__ import annotations
+
+import csv
+import textwrap
+
+import pytest
+import yaml
+from linkml_runtime import SchemaView
+
+from linkml_map.loaders.data_loaders import DataLoader
+from linkml_map.session import Session
+from linkml_map.transformer.engine import transform_spec
+
+SOURCE = yaml.safe_load(
+    textwrap.dedent("""\
+    id: https://example.org/expr-implicit
+    name: expr_implicit
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: expr_implicit
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      Measurement:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+          method: {range: string}
+      Reading:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+          score: {range: float}
+    """)
+)
+
+TARGET = textwrap.dedent("""\
+    id: https://example.org/expr-implicit-target
+    name: expr_implicit_target
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: expr_implicit_target
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      Result:
+        attributes:
+          id: {identifier: true}
+          method: {range: string}
+          reading_score: {range: float}
+""")
+
+# Result pulls a flat slot via expr {Reading.score} — NO joins: block, NO nested CD.
+SPEC = yaml.safe_load(
+    textwrap.dedent("""\
+    id: expr-implicit-transform
+    title: expr implicit join, no joins block
+    class_derivations:
+      Result:
+        populated_from: Measurement
+        slot_derivations:
+          id:
+          method:
+          reading_score:
+            expr: '{Reading.score}'
+    """)
+)
+
+
+@pytest.fixture()
+def data_dir(tmp_path):
+    with open(tmp_path / "Measurement.tsv", "w", newline="") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(["id", "subject_id", "method"])
+        w.writerow(["M1", "S1", "spiro"])
+    with open(tmp_path / "Reading.tsv", "w", newline="") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(["id", "subject_id", "score"])
+        w.writerow(["R1", "S1", "95.5"])
+    return tmp_path
+
+
+def _transformer():
+    session = Session()
+    session.set_source_schema(SOURCE)
+    session.set_object_transformer(SPEC)
+    tr = session.object_transformer
+    tr.source_schemaview = session.source_schemaview
+    tr.target_schemaview = SchemaView(TARGET)
+    return tr
+
+
+def test_expr_reference_synthesizes_join():
+    """The normalizer synthesizes a join for the table referenced only in the expr."""
+    tr = _transformer()
+    result_cd = tr.derived_specification.class_derivations[0]
+    assert result_cd.joins is not None
+    assert "Reading" in result_cd.joins
+    assert result_cd.joins["Reading"].join_on == "subject_id"
+
+
+def test_expr_implicit_join_resolves_value(data_dir):
+    """End to end: {Reading.score} resolves instead of silently returning None."""
+    tr = _transformer()
+    loader = DataLoader(data_dir, schemaview=tr.source_schemaview)
+    results = list(transform_spec(tr, loader, source_type="Measurement"))
+    assert len(results) == 1
+    assert results[0]["reading_score"] == 95.5  # previously None

--- a/tests/test_transformer/test_expression_locations.py
+++ b/tests/test_transformer/test_expression_locations.py
@@ -1,0 +1,110 @@
+"""Tests for expression-location enumeration + the model-driven completeness guard.
+
+The guard is the important one: it introspects the transformer model and fails if
+a new expression-bearing field is added without being registered, so the join
+normalizer can't silently miss a cross-table reference hiding in a new field.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+
+import linkml_map
+from linkml_map.datamodel.transformer_model import (
+    EnumDerivation,
+    KeyVal,
+    PermissibleValueDerivation,
+    SlotDerivation,
+)
+from linkml_map.utils.expression_locations import (
+    MAPPING_EXPR_FIELDS,
+    SELF_EXPR_FIELDS,
+    iter_expressions,
+)
+
+MODEL_PATH = Path(linkml_map.__file__).parent / "datamodel" / "transformer_model.yaml"
+
+
+# --- iter_expressions: pulls exprs from every field shape ---
+
+
+def test_self_expr_on_slot():
+    assert list(iter_expressions(SlotDerivation(name="x", expr="{A.col}"))) == ["{A.col}"]
+
+
+def test_self_expr_on_enum_and_pv():
+    assert list(iter_expressions(EnumDerivation(name="e", expr="{B.col}"))) == ["{B.col}"]
+    assert list(iter_expressions(PermissibleValueDerivation(name="pv", expr="{C.col}"))) == ["{C.col}"]
+
+
+def test_expression_mappings_values_are_exprs():
+    sd = SlotDerivation(name="x", expression_mappings={"k": KeyVal(key="k", value="{A.col}")})
+    assert list(iter_expressions(sd)) == ["{A.col}"]
+
+
+def test_expression_to_value_mappings_keys_are_exprs():
+    sd = SlotDerivation(
+        name="x",
+        expression_to_value_mappings={"{A.col} == 1": KeyVal(key="{A.col} == 1", value="literal")},
+    )
+    assert list(iter_expressions(sd)) == ["{A.col} == 1"]
+
+
+def test_expression_to_expression_mappings_both_sides():
+    sd = SlotDerivation(
+        name="x",
+        expression_to_expression_mappings={"{A.k}": KeyVal(key="{A.k}", value="{B.v}")},
+    )
+    assert set(iter_expressions(sd)) == {"{A.k}", "{B.v}"}
+
+
+def test_value_mappings_are_not_expressions():
+    """Literal value_mappings must not be treated as expressions."""
+    sd = SlotDerivation(name="x", value_mappings={"F": KeyVal(key="F", value="Female")})
+    assert list(iter_expressions(sd)) == []
+
+
+def test_all_fields_combined():
+    sd = SlotDerivation(
+        name="x",
+        expr="{A.a}",
+        expression_mappings={"k": KeyVal(key="k", value="{B.b}")},
+    )
+    assert set(iter_expressions(sd)) == {"{A.a}", "{B.b}"}
+
+
+def test_empty_derivation_yields_nothing():
+    assert list(iter_expressions(SlotDerivation(name="x"))) == []
+
+
+# --- completeness guard: model introspection ---
+
+
+def test_every_model_expression_field_is_registered():
+    """Fail if the model has an expression-bearing field not registered in expression_locations.
+
+    Candidate detection uses the model's own conventions: a ``string`` slot whose
+    description names the "expression language" is a self-expr field; a ``KeyVal``
+    slot whose name starts with ``expression`` is an expression mapping. Adding a
+    new such field to transformer_model.yaml will fail this test until it's
+    registered (and handled by the normalizer).
+    """
+    sv = SchemaView(str(MODEL_PATH))
+    self_fields: set[str] = set()
+    mapping_fields: set[str] = set()
+    for cls in sv.all_classes():
+        for slot in sv.class_induced_slots(cls):
+            desc = slot.description or ""
+            if slot.range == "string" and "expression language" in desc:
+                self_fields.add(slot.name)
+            if slot.range == "KeyVal" and slot.name.startswith("expression"):
+                mapping_fields.add(slot.name)
+
+    unregistered_self = self_fields - set(SELF_EXPR_FIELDS)
+    assert not unregistered_self, f"unregistered self-expr fields: {sorted(unregistered_self)}"
+
+    assert mapping_fields == set(MAPPING_EXPR_FIELDS), (
+        f"expression mapping fields in model {sorted(mapping_fields)} != registered {sorted(MAPPING_EXPR_FIELDS)}"
+    )

--- a/tests/test_transformer/test_expression_locations.py
+++ b/tests/test_transformer/test_expression_locations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from linkml_runtime import SchemaView
 
 import linkml_map
@@ -21,8 +22,11 @@ from linkml_map.datamodel.transformer_model import (
 from linkml_map.utils.expression_locations import (
     MAPPING_EXPR_FIELDS,
     SELF_EXPR_FIELDS,
+    extract_table_references,
     iter_expressions,
 )
+
+TABLES = {"Reading", "Measurement", "pht003099"}
 
 MODEL_PATH = Path(linkml_map.__file__).parent / "datamodel" / "transformer_model.yaml"
 
@@ -77,6 +81,36 @@ def test_all_fields_combined():
 
 def test_empty_derivation_yields_nothing():
     assert list(iter_expressions(SlotDerivation(name="x"))) == []
+
+
+# --- extract_table_references ---
+
+
+def test_extract_dotted_table_reference():
+    assert extract_table_references("{Reading.score}", TABLES) == {"Reading"}
+
+
+def test_extract_ignores_bare_column():
+    assert extract_table_references("{score}", TABLES) == set()
+
+
+def test_extract_ignores_attribute_on_non_table():
+    assert extract_table_references("{notatable.x}", TABLES) == set()
+
+
+def test_extract_multiple_tables_in_one_expression():
+    expr = '{Reading.id} + "_" + {Measurement.id}'
+    assert extract_table_references(expr, TABLES) == {"Reading", "Measurement"}
+
+
+def test_extract_from_realistic_case_expression():
+    expr = "case(({phv00254011} == 1, {pht003099.phv00177946} * 365), (True, 0))"
+    assert extract_table_references(expr, TABLES) == {"pht003099"}
+
+
+def test_extract_malformed_expression_raises():
+    with pytest.raises(SyntaxError):
+        extract_table_references("{Reading.", TABLES)
 
 
 # --- completeness guard: model introspection ---

--- a/tests/test_transformer/test_join_synthesis_completeness.py
+++ b/tests/test_transformer/test_join_synthesis_completeness.py
@@ -133,6 +133,92 @@ def test_top_level_slot_derivation_cross_table_ref_fails_loud():
         _ = tr.derived_specification
 
 
+def test_expr_cross_table_ref_unkeyable_fails_loud():
+    """An expr ref to a table with no inferable join key fails loud, not silent None.
+
+    An expression reference has no runtime safety net (it silently resolves to
+    None), so an un-keyable one must surface at normalization time.
+    """
+    source_no_common = yaml.safe_load(
+        textwrap.dedent("""\
+        id: https://example.org/no-common
+        name: no_common
+        prefixes: {linkml: https://w3id.org/linkml/}
+        default_prefix: no_common
+        default_range: string
+        imports: [linkml:types]
+        classes:
+          Measurement:
+            attributes:
+              id: {identifier: true}
+              method: {range: string}
+          Reading:
+            attributes:
+              reading_id: {identifier: true}
+              score: {range: float}
+        """)
+    )
+    session = Session()
+    session.set_source_schema(source_no_common)
+    session.set_object_transformer(
+        yaml.safe_load(
+            textwrap.dedent("""\
+            id: t
+            title: expr unkeyable
+            class_derivations:
+              Result:
+                populated_from: Measurement
+                slot_derivations:
+                  score:
+                    expr: '{Reading.score}'
+            """)
+        )
+    )
+    tr = session.object_transformer
+    tr.source_schemaview = session.source_schemaview
+    with pytest.raises(ValueError, match="cannot be joined"):
+        _ = tr.derived_specification
+
+
+def test_expr_unknown_qualified_root_fails_loud():
+    """A braced ``{Unknown.col}`` whose root is no known table/slot fails at synthesis.
+
+    A same-row slot reference (``{subject_id.x}``) and a bare reference must not.
+    """
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: unknown qualified root
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              x:
+                expr: '{Nonexistent.col}'
+        """)
+    )
+    with pytest.raises(ValueError, match="cannot be resolved"):
+        _ = tr.derived_specification
+
+
+def test_expr_same_row_qualified_root_is_allowed():
+    """A qualified reference rooted in a source slot (same-row/inlined) is not flagged."""
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: same-row qualified root
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              x:
+                expr: '{subject_id.upper}'
+        """)
+    )
+    # subject_id is a slot on Measurement → resolvable, no raise.
+    assert tr.derived_specification is not None
+
+
 def test_enum_derivation_same_row_reference_is_allowed():
     """A bare (same-row) reference in an enum derivation must not fail — only cross-table does."""
     tr = _transformer(

--- a/tests/test_transformer/test_join_synthesis_completeness.py
+++ b/tests/test_transformer/test_join_synthesis_completeness.py
@@ -219,6 +219,32 @@ def test_expr_same_row_qualified_root_is_allowed():
     assert tr.derived_specification is not None
 
 
+def test_expr_declared_join_alias_is_allowed():
+    """A reference rooted in a declared join alias (alias != schema class) is not flagged.
+
+    Runtime resolves any key in ``class_derivation.joins``; the synthesis guard
+    must mirror that and not raise on ``{alias.col}`` for an aliased explicit join.
+    """
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: declared join alias
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            joins:
+              myreading:
+                class_named: Reading
+                join_on: subject_id
+            slot_derivations:
+              s:
+                expr: '{myreading.score}'
+        """)
+    )
+    # myreading is a declared join alias → resolvable, no raise.
+    assert tr.derived_specification is not None
+
+
 def test_enum_derivation_same_row_reference_is_allowed():
     """A bare (same-row) reference in an enum derivation must not fail — only cross-table does."""
     tr = _transformer(

--- a/tests/test_transformer/test_join_synthesis_completeness.py
+++ b/tests/test_transformer/test_join_synthesis_completeness.py
@@ -1,0 +1,153 @@
+"""Completeness of join synthesis across all model locations.
+
+Two guarantees beyond the basic slot-expr case:
+1. A spec authored with object_derivations (the deprecated multivalued
+   nested-object pattern, flattened into class_derivations at load) still gets
+   its cross-table join synthesized.
+2. A cross-table reference in a derivation with no enclosing class_derivation
+   (top-level enum / permissible-value / slot derivation) fails loud rather than
+   silently resolving to None — there is nowhere to host the join.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+import yaml
+
+from linkml_map.session import Session
+
+SOURCE = yaml.safe_load(
+    textwrap.dedent("""\
+    id: https://example.org/completeness
+    name: completeness
+    prefixes: {linkml: https://w3id.org/linkml/}
+    default_prefix: completeness
+    default_range: string
+    imports: [linkml:types]
+    classes:
+      Measurement:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+      Reading:
+        attributes:
+          id: {identifier: true}
+          subject_id: {range: string}
+          score: {range: float}
+    """)
+)
+
+
+def _transformer(spec_yaml: str):
+    session = Session()
+    session.set_source_schema(SOURCE)
+    session.set_object_transformer(yaml.safe_load(spec_yaml))
+    tr = session.object_transformer
+    tr.source_schemaview = session.source_schemaview
+    return tr
+
+
+def test_object_derivation_nested_table_synthesizes_join():
+    """A spec authored with object_derivations (flattened at load) still gets its join synthesized."""
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: object derivation join
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              readings:
+                object_derivations:
+                  - class_derivations:
+                      Obs:
+                        populated_from: Reading
+                        slot_derivations:
+                          value: {populated_from: score}
+        """)
+    )
+    result_cd = tr.derived_specification.class_derivations[0]
+    assert result_cd.joins is not None
+    assert "Reading" in result_cd.joins
+    assert result_cd.joins["Reading"].join_on == "subject_id"
+
+
+def test_enum_derivation_cross_table_ref_fails_loud():
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: enum cross-table
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              id:
+        enum_derivations:
+          MyEnum:
+            expr: '{Reading.score}'
+        """)
+    )
+    with pytest.raises(ValueError, match="cannot be joined"):
+        _ = tr.derived_specification
+
+
+def test_permissible_value_derivation_cross_table_ref_fails_loud():
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: pv cross-table
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              id:
+        enum_derivations:
+          MyEnum:
+            permissible_value_derivations:
+              PV1:
+                expr: '{Reading.score}'
+        """)
+    )
+    with pytest.raises(ValueError, match="cannot be joined"):
+        _ = tr.derived_specification
+
+
+def test_top_level_slot_derivation_cross_table_ref_fails_loud():
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: top-level slot cross-table
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              id:
+        slot_derivations:
+          loose:
+            expr: '{Reading.score}'
+        """)
+    )
+    with pytest.raises(ValueError, match="cannot be joined"):
+        _ = tr.derived_specification
+
+
+def test_enum_derivation_same_row_reference_is_allowed():
+    """A bare (same-row) reference in an enum derivation must not fail — only cross-table does."""
+    tr = _transformer(
+        textwrap.dedent("""\
+        id: t
+        title: enum same-row
+        class_derivations:
+          Result:
+            populated_from: Measurement
+            slot_derivations:
+              id:
+        enum_derivations:
+          MyEnum:
+            expr: '{subject_id}'
+        """)
+    )
+    # Computing the derived spec must not raise.
+    assert tr.derived_specification is not None

--- a/tests/test_utils/test_eval_utils.py
+++ b/tests/test_utils/test_eval_utils.py
@@ -1303,3 +1303,19 @@ def test_case_converters_distribute_and_propagate_none() -> None:
         "SnakeCase",
         "HttpResponse",
     ]
+
+
+def test_qualified_unknown_root_fails_loud() -> None:
+    """A qualified ``{Unknown.col}`` whose root is unbound raises, even non-strict.
+
+    Distinct from a bare ``{missing}`` (legitimate SQL null) and a known-but-None
+    root (sparse-join miss), both of which stay null.
+    """
+    with pytest.raises(NameError, match="unknown 'Nope'"):
+        eval_expr("{Nope.col}", a=1)
+
+
+def test_bare_absent_and_known_none_stay_null() -> None:
+    """Bare absent names and known-but-None roots null out rather than raising."""
+    assert eval_expr("{missing}", a=1) is None
+    assert eval_expr("{a.b}", a=None) is None

--- a/tests/test_utils/test_join_utils.py
+++ b/tests/test_utils/test_join_utils.py
@@ -1,0 +1,82 @@
+"""Tests for join-key inference."""
+
+from __future__ import annotations
+
+import textwrap
+
+from linkml_runtime import SchemaView
+
+from linkml_map.utils.join_utils import infer_join_key, pick_join_key
+
+
+def test_prefers_subject_key_over_other_common_columns():
+    """dbGaP_Subject_ID wins even when another common column exists (which pick_join_key can't pick)."""
+    sv = SchemaView(
+        textwrap.dedent("""\
+        id: x
+        name: x
+        prefixes: {linkml: https://w3id.org/linkml/}
+        default_prefix: x
+        default_range: string
+        imports: [linkml:types]
+        classes:
+          A:
+            attributes:
+              a_id: {identifier: true}
+              dbGaP_Subject_ID: {range: string}
+              site: {range: string}
+          B:
+            attributes:
+              b_id: {identifier: true}
+              dbGaP_Subject_ID: {range: string}
+              site: {range: string}
+        """)
+    )
+    # pick_join_key is ambiguous (two non-id common cols) -> None
+    assert pick_join_key(sv, "A", "B") is None
+    # inference prefers the subject key
+    assert infer_join_key(sv, "A", "B") == "dbGaP_Subject_ID"
+
+
+def test_falls_back_to_pick_join_key_without_subject_key():
+    sv = SchemaView(
+        textwrap.dedent("""\
+        id: x
+        name: x
+        prefixes: {linkml: https://w3id.org/linkml/}
+        default_prefix: x
+        default_range: string
+        imports: [linkml:types]
+        classes:
+          A:
+            attributes:
+              a_id: {identifier: true}
+              subject_id: {range: string}
+          B:
+            attributes:
+              b_id: {identifier: true}
+              subject_id: {range: string}
+        """)
+    )
+    assert infer_join_key(sv, "A", "B") == "subject_id"
+
+
+def test_returns_none_when_no_common_column():
+    sv = SchemaView(
+        textwrap.dedent("""\
+        id: x
+        name: x
+        prefixes: {linkml: https://w3id.org/linkml/}
+        default_prefix: x
+        default_range: string
+        imports: [linkml:types]
+        classes:
+          A:
+            attributes:
+              a_id: {identifier: true}
+          B:
+            attributes:
+              b_id: {identifier: true}
+        """)
+    )
+    assert infer_join_key(sv, "A", "B") is None

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -977,6 +977,45 @@ def test_nested_cd_implicit_join_emits_info():
     assert _nested_path_segment(infos[0].path)
 
 
+def test_derived_spec_synthesized_join_is_observed_not_predicted():
+    """Validating the *derived* spec observes the synthesized join instead of predicting it.
+
+    Against the raw spec the validator emits an INFO predicting synthesis; against
+    the post-synthesis (derived) spec the join is already explicit, so the
+    prediction must not fire (it would be a misleading pre-synthesis warning).
+    """
+    import yaml
+
+    from linkml_map.session import Session
+
+    spec_yaml = {
+        "id": "t",
+        "title": "t",
+        "class_derivations": {
+            "Outer": {
+                "populated_from": "Measurement",
+                "slot_derivations": {
+                    "observation": {
+                        "class_derivations": [
+                            {"Inner": {"populated_from": "Reading", "slot_derivations": {"score": None}}}
+                        ]
+                    }
+                },
+            }
+        },
+    }
+    session = Session()
+    session.set_source_schema(yaml.safe_load(JOINABLE_SCHEMA))
+    session.set_object_transformer(spec_yaml)
+    tr = session.object_transformer
+    tr.source_schemaview = session.source_schemaview
+
+    derived = tr.derived_specification.model_dump(exclude_none=True)
+    msgs = validate_spec_semantics(derived, source_schemaview=session.source_schemaview)
+    predictions = [m for m in msgs if "will be synthesized" in m.message]
+    assert predictions == []
+
+
 def test_nested_cd_no_overlap_emits_warning():
     """No shared columns between parent and nested tables emits a WARNING (closes #211)."""
     sv = SchemaView(NO_OVERLAP_SCHEMA)


### PR DESCRIPTION
Normalizes every implicit cross-table reference into an explicit `joins:` entry so any execution backend sees one join form. Detection only — no model change, no execution-strategy change.

**The bug it fixes**
- A `{Table.col}` reference in an `expr` with no `joins:` block (and no nested class_derivation for that table) was never synthesized into a join and silently resolved to `None`. Join synthesis only walked nested class_derivations.
- This is the dominant real pattern: `bdc-harmonized-variables` is 440 specs with **zero** `joins:` blocks, relying entirely on `expr: {phtNNNN.col}`.

**What changed**
- Synthesis now scans every expression for `{Table.col}` and synthesizes an explicit join on the enclosing class_derivation. `iter_expressions` covers all model-enumerated expression locations (`expr` on slot/enum/PV, plus the `expression*` KeyVal mappings).
- `extract_table_references` AST-parses an expression (exec mode — the language allows assignment/comprehension syntax) and returns referenced source-schema classes. An `available` set tracks the ancestor source chain so parent/own-row refs aren't treated as new joins.
- `infer_join_key` prefers a consistently-named subject id (`dbGaP_Subject_ID`, present in prepared dbGaP tables) over the structural heuristic, falling back to `pick_join_key`.
- **Completeness guard**: a test introspects the transformer model and fails if a new expression-bearing field is added without being registered — so the normalizer can't silently miss a join again.
- A cross-table ref in a derivation with no enclosing class_derivation (top-level enum / permissible-value / slot derivation) **fails loud** instead of silently nulling — there's nowhere to host the join.

**Behavior changes**
- `expr: {Table.col}` with no `joins:` block now resolves (was `None`).
- A cross-table ref in a top-level enum/PV/slot derivation now raises `ValueError` (was silent `None`).

**Notes**
- Decoupled from execution — this fixes correctness for the current per-row engine too, and feeds the planned DuckDB join engine.
- 980 tests pass (new: `test_expression_locations`, `test_join_utils`, `test_expr_implicit_join`, `test_join_synthesis_completeness`).