### PR TITLE
Publish to PyPI on release published, not created

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -3,7 +3,7 @@ name: Publish Python Package
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
`pypi-publish.yaml` triggers on `release: types: [created]`, which does **not** fire when a saved draft release is published — GitHub emits `published`/`released` for that, not `created`. So cutting a release as a draft and then hitting Publish silently skips the PyPI upload.

This bit **v0.5.3-rc2**: the GitHub release + tag existed but nothing published to PyPI; it had to be dispatched manually via `workflow_dispatch`.

**Fix:** trigger on `types: [published]`, which fires for both direct-as-published and draft-then-publish releases, including pre-releases. A single type (rather than `[created, published]`) avoids a double run on a direct publish, where the second run would fail uploading an already-existing PyPI version.