### PR TITLE
Report --continue-on-error errors as they occur so a mid-stream crash can't drop them

### DIFF
--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -435,11 +435,12 @@ def _map_data_streaming(
     data_loader = DataLoader(input_path, schemaview=tr.source_schemaview)
 
     # When continue-on-error is enabled, report each row error as it occurs so
-    # nothing is lost if a later write crashes; the list drives the exit code.
-    errors: list[TransformationError] = []
+    # nothing is lost if a later write crashes; a count drives the exit code.
+    error_count = 0
 
     def report_error(err: TransformationError) -> None:
-        errors.append(err)
+        nonlocal error_count
+        error_count += 1
         click.echo(f"  - {err}", err=True)
 
     on_error = report_error if continue_on_error else None
@@ -491,8 +492,8 @@ def _map_data_streaming(
 
     # Errors were already printed as they occurred; a mid-stream crash would
     # have propagated before reaching here. Reached only on clean completion.
-    if errors:
-        click.echo(f"\n{len(errors)} transformation error(s)", err=True)
+    if error_count:
+        click.echo(f"\n{error_count} transformation error(s)", err=True)
         raise SystemExit(1)
 
 

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -449,45 +449,55 @@ def _map_data_streaming(
         msg = f"Unsupported output format: {output_format}"
         raise click.ClickException(msg) from None
 
-    if additional_output:
-        extra_outputs = _build_additional_outputs(additional_output)
+    completed = False
+    try:
+        if additional_output:
+            extra_outputs = _build_additional_outputs(additional_output)
 
-        # Validate no duplicate paths between primary and additional outputs
-        if output:
-            primary_resolved = Path(output).resolve()
-            extra_paths = {p.resolve() for _, p in extra_outputs}
-            if primary_resolved in extra_paths:
-                msg = f"Primary output path duplicated in -O: {output}"
-                raise click.ClickException(msg)
+            # Validate no duplicate paths between primary and additional outputs
+            if output:
+                primary_resolved = Path(output).resolve()
+                extra_paths = {p.resolve() for _, p in extra_outputs}
+                if primary_resolved in extra_paths:
+                    msg = f"Primary output path duplicated in -O: {output}"
+                    raise click.ClickException(msg)
 
-        primary_writer = make_stream_writer(fmt)
-        primary_target = Path(output) if output else sys.stdout
-        all_outputs = [(primary_writer, primary_target), *extra_outputs]
-        MultiStreamWriter(all_outputs).write_all(chunks)
-    else:
-        # Original single-output path (backward compatible)
-        stream_writer = get_stream_writer(fmt)
+            primary_writer = make_stream_writer(fmt)
+            primary_target = Path(output) if output else sys.stdout
+            all_outputs = [(primary_writer, primary_target), *extra_outputs]
+            MultiStreamWriter(all_outputs).write_all(chunks)
+        else:
+            # Original single-output path (backward compatible)
+            stream_writer = get_stream_writer(fmt)
 
-        output_ctx = open(output, "w", encoding="utf-8") if output else nullcontext(sys.stdout)
-        with output_ctx as output_file:
-            for chunk_str in stream_writer(chunks):
-                output_file.write(chunk_str)
+            output_ctx = open(output, "w", encoding="utf-8") if output else nullcontext(sys.stdout)
+            with output_ctx as output_file:
+                for chunk_str in stream_writer(chunks):
+                    output_file.write(chunk_str)
 
-        # Handle header rewrite for tabular output if needed
-        if output and hasattr(stream_writer, "headers"):
-            logger.info("Rewriting output with updated headers")
-            tmp_path = output + ".tmp"
-            with open(output, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
-                separator = "\t" if output_format == "tsv" else ","
-                for line in rewrite_header_and_pad(iter(src), stream_writer.headers, separator, chunk_size):
-                    dst.write(line)
-            os.replace(tmp_path, output)
+            # Handle header rewrite for tabular output if needed
+            if output and hasattr(stream_writer, "headers"):
+                logger.info("Rewriting output with updated headers")
+                tmp_path = output + ".tmp"
+                with open(output, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
+                    separator = "\t" if output_format == "tsv" else ","
+                    for line in rewrite_header_and_pad(iter(src), stream_writer.headers, separator, chunk_size):
+                        dst.write(line)
+                os.replace(tmp_path, output)
 
-    # Report collected errors
-    if errors:
-        click.echo(f"\n{len(errors)} transformation error(s):", err=True)
-        for err in errors:
-            click.echo(f"  - {err}", err=True)
+        completed = True
+    finally:
+        # Flush collected errors even if output writing crashed mid-stream, so
+        # they aren't lost. Only print here; raising SystemExit inside finally
+        # would replace an in-flight crash and swallow its traceback.
+        if errors:
+            click.echo(f"\n{len(errors)} transformation error(s):", err=True)
+            for err in errors:
+                click.echo(f"  - {err}", err=True)
+
+    # Reached only on clean completion; a mid-stream crash has already
+    # propagated through the finally above with its traceback intact.
+    if completed and errors:
         raise SystemExit(1)
 
 

--- a/src/linkml_map/cli/cli.py
+++ b/src/linkml_map/cli/cli.py
@@ -434,9 +434,15 @@ def _map_data_streaming(
     # Initialize data loader (schema enables type-preserving coercion for TSV/CSV)
     data_loader = DataLoader(input_path, schemaview=tr.source_schemaview)
 
-    # Set up error collection when continue-on-error is enabled
+    # When continue-on-error is enabled, report each row error as it occurs so
+    # nothing is lost if a later write crashes; the list drives the exit code.
     errors: list[TransformationError] = []
-    on_error = errors.append if continue_on_error else None
+
+    def report_error(err: TransformationError) -> None:
+        errors.append(err)
+        click.echo(f"  - {err}", err=True)
+
+    on_error = report_error if continue_on_error else None
 
     # Create transform iterator and chunk it
     transform_iter = transform_spec(tr, data_loader, source_type, on_error=on_error)
@@ -449,55 +455,44 @@ def _map_data_streaming(
         msg = f"Unsupported output format: {output_format}"
         raise click.ClickException(msg) from None
 
-    completed = False
-    try:
-        if additional_output:
-            extra_outputs = _build_additional_outputs(additional_output)
+    if additional_output:
+        extra_outputs = _build_additional_outputs(additional_output)
 
-            # Validate no duplicate paths between primary and additional outputs
-            if output:
-                primary_resolved = Path(output).resolve()
-                extra_paths = {p.resolve() for _, p in extra_outputs}
-                if primary_resolved in extra_paths:
-                    msg = f"Primary output path duplicated in -O: {output}"
-                    raise click.ClickException(msg)
+        # Validate no duplicate paths between primary and additional outputs
+        if output:
+            primary_resolved = Path(output).resolve()
+            extra_paths = {p.resolve() for _, p in extra_outputs}
+            if primary_resolved in extra_paths:
+                msg = f"Primary output path duplicated in -O: {output}"
+                raise click.ClickException(msg)
 
-            primary_writer = make_stream_writer(fmt)
-            primary_target = Path(output) if output else sys.stdout
-            all_outputs = [(primary_writer, primary_target), *extra_outputs]
-            MultiStreamWriter(all_outputs).write_all(chunks)
-        else:
-            # Original single-output path (backward compatible)
-            stream_writer = get_stream_writer(fmt)
+        primary_writer = make_stream_writer(fmt)
+        primary_target = Path(output) if output else sys.stdout
+        all_outputs = [(primary_writer, primary_target), *extra_outputs]
+        MultiStreamWriter(all_outputs).write_all(chunks)
+    else:
+        # Original single-output path (backward compatible)
+        stream_writer = get_stream_writer(fmt)
 
-            output_ctx = open(output, "w", encoding="utf-8") if output else nullcontext(sys.stdout)
-            with output_ctx as output_file:
-                for chunk_str in stream_writer(chunks):
-                    output_file.write(chunk_str)
+        output_ctx = open(output, "w", encoding="utf-8") if output else nullcontext(sys.stdout)
+        with output_ctx as output_file:
+            for chunk_str in stream_writer(chunks):
+                output_file.write(chunk_str)
 
-            # Handle header rewrite for tabular output if needed
-            if output and hasattr(stream_writer, "headers"):
-                logger.info("Rewriting output with updated headers")
-                tmp_path = output + ".tmp"
-                with open(output, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
-                    separator = "\t" if output_format == "tsv" else ","
-                    for line in rewrite_header_and_pad(iter(src), stream_writer.headers, separator, chunk_size):
-                        dst.write(line)
-                os.replace(tmp_path, output)
+        # Handle header rewrite for tabular output if needed
+        if output and hasattr(stream_writer, "headers"):
+            logger.info("Rewriting output with updated headers")
+            tmp_path = output + ".tmp"
+            with open(output, encoding="utf-8") as src, open(tmp_path, "w", encoding="utf-8") as dst:
+                separator = "\t" if output_format == "tsv" else ","
+                for line in rewrite_header_and_pad(iter(src), stream_writer.headers, separator, chunk_size):
+                    dst.write(line)
+            os.replace(tmp_path, output)
 
-        completed = True
-    finally:
-        # Flush collected errors even if output writing crashed mid-stream, so
-        # they aren't lost. Only print here; raising SystemExit inside finally
-        # would replace an in-flight crash and swallow its traceback.
-        if errors:
-            click.echo(f"\n{len(errors)} transformation error(s):", err=True)
-            for err in errors:
-                click.echo(f"  - {err}", err=True)
-
-    # Reached only on clean completion; a mid-stream crash has already
-    # propagated through the finally above with its traceback intact.
-    if completed and errors:
+    # Errors were already printed as they occurred; a mid-stream crash would
+    # have propagated before reaching here. Reached only on clean completion.
+    if errors:
+        click.echo(f"\n{len(errors)} transformation error(s)", err=True)
         raise SystemExit(1)
 
 

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -1,6 +1,7 @@
 """Integration tests for CLI with tabular (TSV/CSV) input."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -767,3 +768,62 @@ class TestContinueOnError:
         assert result.exit_code == 0
         lines = [line for line in result.stdout.strip().split("\n") if line]
         assert len(lines) == 2
+
+    @pytest.mark.skipif(not os.path.exists("/dev/full"), reason="requires /dev/full device")
+    def test_collected_errors_flushed_when_output_crashes(
+        self,
+        runner: CliRunner,
+        sample_schema: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Errors collected before a hard mid-stream crash are still reported, and the crash surfaces.
+
+        Uses /dev/full so the write fails with OSError after a row-level
+        TransformationError has been collected. The accumulated error must be
+        flushed (not lost behind the crash) and the OSError must still propagate.
+        """
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        # Row 1 divides by zero (collected error); row 2 succeeds and gets written.
+        (data_dir / "Person.tsv").write_text(
+            "id\tname\tprimary_email\tage_in_years\tgender\n"
+            "P:001\tAlice\talice@example.com\t0\tcisgender woman\n"
+            "P:002\tBob\tbob@example.com\t25\tcisgender man\n"
+        )
+        transform_path = tmp_path / "ratio_transform.yaml"
+        transform = {
+            "id": "ratio-transform",
+            "class_derivations": {
+                "Agent": {
+                    "populated_from": "Person",
+                    "slot_derivations": {
+                        "id": {},
+                        "ratio": {"expr": "100 / {age_in_years}"},
+                    },
+                }
+            },
+        }
+        transform_path.write_text(yaml.dump(transform))
+
+        result = runner.invoke(
+            main,
+            [
+                "map-data",
+                "-T",
+                str(transform_path),
+                "-s",
+                str(sample_schema),
+                "-f",
+                "jsonl",
+                "--continue-on-error",
+                "-o",
+                "/dev/full",
+                str(data_dir),
+            ],
+        )
+        # The collected error is flushed to stderr...
+        assert "1 transformation error(s)" in result.stderr
+        assert "slot_derivation=ratio" in result.stderr
+        # ...and the hard crash still surfaces rather than being masked.
+        assert result.exit_code != 0
+        assert isinstance(result.exception, OSError)

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -776,11 +776,11 @@ class TestContinueOnError:
         sample_schema: Path,
         tmp_path: Path,
     ) -> None:
-        """Errors collected before a hard mid-stream crash are still reported, and the crash surfaces.
+        """A row error reported before a hard mid-stream crash survives, and the crash surfaces.
 
         Uses /dev/full so the write fails with OSError after a row-level
-        TransformationError has been collected. The accumulated error must be
-        flushed (not lost behind the crash) and the OSError must still propagate.
+        TransformationError has already been printed. The error must not be lost
+        behind the crash, and the OSError must still propagate.
         """
         data_dir = tmp_path / "data"
         data_dir.mkdir()

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -821,8 +821,7 @@ class TestContinueOnError:
                 str(data_dir),
             ],
         )
-        # The collected error is flushed to stderr...
-        assert "1 transformation error(s)" in result.stderr
+        # The row error was printed as it occurred, so it survives the crash...
         assert "slot_derivation=ratio" in result.stderr
         # ...and the hard crash still surfaces rather than being masked.
         assert result.exit_code != 0

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -784,7 +784,8 @@ class TestContinueOnError:
         """
         data_dir = tmp_path / "data"
         data_dir.mkdir()
-        # Row 1 divides by zero (collected error); row 2 succeeds and gets written.
+        # Row 1 divides by zero (reported error); row 2 transforms, and writing it
+        # to /dev/full triggers the OSError (it is not actually persisted).
         (data_dir / "Person.tsv").write_text(
             "id\tname\tprimary_email\tage_in_years\tgender\n"
             "P:001\tAlice\talice@example.com\t0\tcisgender woman\n"

--- a/tests/test_cli/test_cli_tabular.py
+++ b/tests/test_cli/test_cli_tabular.py
@@ -770,7 +770,7 @@ class TestContinueOnError:
         assert len(lines) == 2
 
     @pytest.mark.skipif(not os.path.exists("/dev/full"), reason="requires /dev/full device")
-    def test_collected_errors_flushed_when_output_crashes(
+    def test_reported_error_survives_output_crash(
         self,
         runner: CliRunner,
         sample_schema: Path,


### PR DESCRIPTION
## Problem

With `--continue-on-error` on the streaming (tabular/directory) path, row-level `TransformationError`s were collected into a list and only reported *after* all output had been written. If a non-`TransformationError` crash occurred mid-stream (e.g. an `OSError` from the writer, a broken pipe), the report block was skipped entirely and **every collected error was silently discarded** — you saw only the crash traceback, with no hint that other rows also failed.

## Fix

Report each error the moment it's collected, in the `on_error` callback, instead of batching to the end. Because nothing is buffered, a later hard crash can't discard diagnostics — the already-printed errors stay on stderr and the crash propagates untouched with its full traceback and non-zero exit. A running integer count (not a retained list of error objects) drives the final tally and exit code on clean completion.

Notes:
- On a mid-stream **crash** you get the per-row error lines (each self-describing: class/slot derivation + row index) followed by the crash traceback — but not the summary count, since the run never reaches clean completion. A crash-path total was never guaranteeable; losing it was the original bug.
- The single-object path was never affected — it reports immediately on catch.

## Test

`test_collected_errors_flushed_when_output_crashes` uses `/dev/full` to force a real `OSError` mid-write after a row-level error has already been reported, then asserts both that the error reached stderr and that the `OSError` still surfaces. Guarded with `skipif` for platforms without `/dev/full`.
