### PR TITLE
Reuse source SchemaView for TSV/CSV coercion instead of rebuilding per file

### DIFF
--- a/src/linkml_map/loaders/data_loaders.py
+++ b/src/linkml_map/loaders/data_loaders.py
@@ -36,6 +36,51 @@ class FileFormat(str, Enum):
         return mapping[ext]
 
 
+_NUMERIC_TYPE_NAMES = frozenset({"integer", "float", "double", "decimal"})
+
+
+def _numeric_slots_for(schemaview: SchemaView, target_class: str) -> set[str]:
+    """
+    Return the names of ``target_class`` slots whose range is a numeric type.
+
+    Mirrors the numeric-slot detection in linkml's delimited loader, but operates
+    on an already-built :class:`SchemaView` so the source schema is parsed once for
+    the whole run instead of being rebuilt from disk per file. Rebuilding per file
+    is both slow and leaky on large generated schemas. See linkml/linkml-map#283.
+
+    :param schemaview: Source schema, built once and reused across files.
+    :param target_class: Source class the file's rows conform to.
+    :return: Slot names (and aliases) whose range resolves to a numeric type.
+    """
+    numeric: set[str] = set()
+    all_types = schemaview.all_types()
+    for slot in schemaview.class_induced_slots(target_class):
+        if slot.range in all_types and any(
+            ancestor in _NUMERIC_TYPE_NAMES for ancestor in schemaview.type_ancestors(slot.range)
+        ):
+            numeric.add(slot.name)
+            if slot.alias:
+                numeric.add(slot.alias)
+    return numeric
+
+
+def _apply_numeric_slots(loader: Any, schemaview: SchemaView | None, target_class: str | None) -> None:
+    """
+    Configure schema-aware numeric coercion on a linkml delimited loader.
+
+    Assigns the numeric-slot set (computed from the in-scope, already-built
+    :class:`SchemaView`) to the loader so it coerces only numeric-ranged columns,
+    without linkml rebuilding a ``SchemaView`` per file. When no schema/class is
+    available the loader keeps its default (coerce every numeric-looking value).
+    See linkml/linkml-map#283.
+
+    ``_numeric_slots`` is linkml's own hook for this; the durable fix is upstream
+    support for handing the loader a ready-made ``SchemaView`` (linkml/linkml#3610).
+    """
+    if schemaview is not None and target_class is not None:
+        loader._numeric_slots = _numeric_slots_for(schemaview, target_class)
+
+
 class BaseFileLoader(ABC):
     """Abstract base class for file loaders."""
 
@@ -84,25 +129,21 @@ class TsvFileLoader(BaseFileLoader):
         self,
         source: str | Path,
         skip_empty_rows: bool = True,
-        schema_path: str | Path | None = None,
+        schemaview: SchemaView | None = None,
         target_class: str | None = None,
     ) -> None:
         """Initialize TSV loader."""
         super().__init__(source)
         self.skip_empty_rows = skip_empty_rows
-        self.schema_path = schema_path
+        self.schemaview = schemaview
         self.target_class = target_class
 
     def iter_instances(self) -> Iterator[dict[str, Any]]:
         """Iterate over rows from the TSV file."""
         from linkml.validator.loaders import TsvLoader
 
-        loader = TsvLoader(
-            str(self.source),
-            skip_empty_rows=self.skip_empty_rows,
-            schema_path=self.schema_path,
-            target_class=self.target_class,
-        )
+        loader = TsvLoader(str(self.source), skip_empty_rows=self.skip_empty_rows)
+        _apply_numeric_slots(loader, self.schemaview, self.target_class)
         yield from loader.iter_instances()
 
 
@@ -113,25 +154,21 @@ class CsvFileLoader(BaseFileLoader):
         self,
         source: str | Path,
         skip_empty_rows: bool = True,
-        schema_path: str | Path | None = None,
+        schemaview: SchemaView | None = None,
         target_class: str | None = None,
     ) -> None:
         """Initialize CSV loader."""
         super().__init__(source)
         self.skip_empty_rows = skip_empty_rows
-        self.schema_path = schema_path
+        self.schemaview = schemaview
         self.target_class = target_class
 
     def iter_instances(self) -> Iterator[dict[str, Any]]:
         """Iterate over rows from the CSV file."""
         from linkml.validator.loaders import CsvLoader
 
-        loader = CsvLoader(
-            str(self.source),
-            skip_empty_rows=self.skip_empty_rows,
-            schema_path=self.schema_path,
-            target_class=self.target_class,
-        )
+        loader = CsvLoader(str(self.source), skip_empty_rows=self.skip_empty_rows)
+        _apply_numeric_slots(loader, self.schemaview, self.target_class)
         yield from loader.iter_instances()
 
 
@@ -218,20 +255,18 @@ class DataLoader:
         """
         Build schema-aware kwargs for a TSV/CSV leaf loader.
 
-        linkml's delimited loader currently takes a ``schema_path``, so we bridge
-        the in-scope :class:`SchemaView` to its source file. When that loader gains
-        native ``SchemaView`` support, this is the single spot that changes.
+        Passes the in-scope :class:`SchemaView` (built once) straight through to the
+        leaf loader, so numeric-slot detection reuses it rather than rebuilding a
+        ``SchemaView`` from disk per file (slow and memory-leaky on large generated
+        schemas). See linkml/linkml-map#283.
 
         :param identifier: Names the source class the file's rows conform to.
-        :return: ``schema_path``/``target_class`` kwargs, or empty if no schema is
-            available (in-memory schemas with no source file degrade to no coercion).
+        :return: ``schemaview``/``target_class`` kwargs, or empty if no schema is
+            available (rows then coerce every numeric-looking value, as before).
         """
         if self.schemaview is None:
             return {}
-        schema_path = self.schemaview.schema.source_file
-        if schema_path is None:
-            return {}
-        return {"schema_path": schema_path, "target_class": identifier}
+        return {"schemaview": self.schemaview, "target_class": identifier}
 
     @property
     def is_single_file(self) -> bool:

--- a/tests/test_loaders/test_data_loader.py
+++ b/tests/test_loaders/test_data_loader.py
@@ -390,7 +390,7 @@ class TestSchemaAwareTsvFileLoader:
     """TsvFileLoader preserves string/enum columns when given a schema."""
 
     def test_with_schema(self, schema_aware_tsv: Path, schema_file: Path) -> None:
-        loader = TsvFileLoader(schema_aware_tsv, schema_path=schema_file, target_class="Record")
+        loader = TsvFileLoader(schema_aware_tsv, schemaview=SchemaView(str(schema_file)), target_class="Record")
         row = next(loader.iter_instances())
         _assert_schema_aware_row(row)
 
@@ -405,7 +405,7 @@ class TestSchemaAwareCsvFileLoader:
     """CsvFileLoader preserves string/enum columns when given a schema."""
 
     def test_with_schema(self, schema_aware_csv: Path, schema_file: Path) -> None:
-        loader = CsvFileLoader(schema_aware_csv, schema_path=schema_file, target_class="Record")
+        loader = CsvFileLoader(schema_aware_csv, schemaview=SchemaView(str(schema_file)), target_class="Record")
         row = next(loader.iter_instances())
         _assert_schema_aware_row(row)
 
@@ -422,16 +422,16 @@ class TestSchemaAwareGetFileLoader:
     @pytest.mark.parametrize("fixture_name", ["schema_aware_tsv", "schema_aware_csv"])
     def test_with_schema(self, fixture_name: str, schema_file: Path, request: pytest.FixtureRequest) -> None:
         data_file = request.getfixturevalue(fixture_name)
-        loader = get_file_loader(data_file, schema_path=schema_file, target_class="Record")
+        loader = get_file_loader(data_file, schemaview=SchemaView(str(schema_file)), target_class="Record")
         row = next(loader.iter_instances())
         _assert_schema_aware_row(row)
 
     def test_rejected_for_yaml(self, tmp_path: Path, schema_file: Path) -> None:
-        """schema_path/target_class are not valid kwargs for non-tabular loaders."""
+        """schemaview/target_class are not valid kwargs for non-tabular loaders."""
         yaml_path = tmp_path / "data.yaml"
         yaml_path.write_text(yaml.dump({"id": 1, "zipcode": "90210"}))
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            get_file_loader(yaml_path, schema_path=schema_file, target_class="Record")
+            get_file_loader(yaml_path, schemaview=SchemaView(str(schema_file)), target_class="Record")
 
 
 class TestSchemaAwareDataLoader:
@@ -491,3 +491,28 @@ class TestSchemaAwareDataLoader:
 
         assert coded["code"] == "007"  # string range preserved
         assert numbered["code"] == 7  # integer range coerced
+
+    def test_reuses_schemaview_without_rebuilding_from_path(self, tmp_path: Path, schema_file: Path) -> None:
+        """Leaf-loader kwargs carry the already-built SchemaView, never a path.
+
+        Forwarding a ``schema_path`` made linkml rebuild a SchemaView per file,
+        which is slow and leaks memory on large generated schemas (see #283). The
+        fix hands the single in-scope SchemaView straight through.
+        """
+        sv = SchemaView(str(schema_file))
+        loader = DataLoader(tmp_path, schemaview=sv)
+        kwargs = loader._schema_loader_kwargs("Record")
+        assert kwargs["schemaview"] is sv  # reused, not rebuilt
+        assert kwargs["target_class"] == "Record"
+        assert "schema_path" not in kwargs  # no path => linkml won't rebuild
+
+    def test_schema_aware_coercion_without_source_file(self, tmp_path: Path, schema_file: Path) -> None:
+        """Coercion is driven by the in-scope SchemaView, so it works even when the
+        schema has no ``source_file`` on disk (previously degraded to coercing
+        every numeric-looking value)."""
+        sv = SchemaView(str(schema_file))
+        sv.schema.source_file = None
+        (tmp_path / "Record.tsv").write_text("id\tzipcode\tscore\tweight\n1\t90210\t2\t3.5\n")
+        loader = DataLoader(tmp_path, schemaview=sv)
+        row = next(loader["Record"])
+        _assert_schema_aware_row(row)


### PR DESCRIPTION
## Problem

Schema-aware TSV/CSV loading (added in ff846709) forwards a `schema_path` into linkml's `TsvLoader`/`CsvLoader`. linkml's `_get_numeric_slots` then builds a **fresh `SchemaView` from disk per file**. On a large generated (schema-automator) source schema, each build is expensive **and leaks ~11 MB that gc can't reclaim** (measured: linear, no plateau — 40 builds → 510 MB, 150 → 1.77 GB).

A directory transform runs one load per `class_derivation` (hundreds), so RSS climbs to tens of GB. In practice the run either thrashes on swap (8 min → 45 min+) or gets **OOM-killed mid-stream**. Because the caller streams output in chunks and swallows the child exit code, that surfaces as **silently truncated or 0-byte output** rather than an error — worse on sparse inputs, which haven't flushed a chunk yet when the kill lands.

## Fix

`DataLoader` already holds exactly one built `SchemaView`. Compute the numeric-slot set from that **reused** view and assign it to the leaf loader via linkml's own `_numeric_slots` hook, so the source schema is parsed **once for the whole run** instead of per file. No `schema_path` is forwarded, so linkml never rebuilds.

- Peak RSS is now **flat** across many file loads (verified: 60 loads of the same table stay at 143 MB; previously ~700 MB and climbing).
- Coercion behavior is **unchanged for file-backed schemas**, and now also works for **in-memory schemas** (which previously degraded to coercing every numeric-looking value, because the old path needed `source_file`).

The durable fix is upstream support for handing the delimited loader a ready-made `SchemaView` (linkml/linkml#3610); this reuses linkml's `_numeric_slots` hook until then.

## Tests

- Existing schema-aware coercion tests updated to the new leaf-loader interface (`schemaview=`/`target_class=` instead of `schema_path=`); assertions unchanged.
- Added: kwargs carry the reused `SchemaView` object and no `schema_path`; coercion works when the schema has no `source_file`.
- Full suite green (1043 passed).

Closes #283
Closes #284 — confirmed on live data (CHS c4): memory stays low and the previously empty/truncated entity outputs are produced in full.