### PR TITLE
Evaluate arithmetic numerically when an operand is a string

### DIFF
--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -443,6 +443,67 @@ def _maybe_coerce_numeric(left: Any, right: Any) -> tuple[Any, Any]:  # noqa: AN
     return left, right
 
 
+def _coerce_like(s: str, num: int | float) -> int | float | None:  # noqa: ANN401
+    """Convert numeric string ``s`` to ``num``'s type, falling back to float.
+
+    Returns ``None`` when ``s`` is not numeric-looking.
+
+    >>> _coerce_like("71", 365)
+    71
+    >>> _coerce_like("3.14", 2)
+    3.14
+    >>> _coerce_like("abc", 2) is None
+    True
+    """
+    try:
+        return type(num)(s)
+    except (ValueError, TypeError):
+        return _try_numeric(s)
+
+
+def _maybe_coerce_arithmetic(left: Any, right: Any) -> tuple[Any, Any]:  # noqa: ANN401
+    """
+    Coerce a numeric-string operand so an arithmetic operator evaluates numerically.
+
+    Tabular loaders keep genuinely string-typed columns as strings even when the
+    values look numeric (see linkml/linkml-map#285). Without coercion, ``*`` would
+    apply Python's string semantics -- ``"71" * 365`` repeats the string 365 times
+    instead of computing ``25915`` -- silently corrupting output rather than erroring.
+
+    When exactly one operand is a number and the other a numeric-looking string, the
+    string is converted to a number (matching the number's type when it parses
+    cleanly, else ``float``). Two strings (so ``"a" + "b"`` still concatenates) and a
+    number paired with a non-numeric string are returned unchanged.
+
+    >>> _maybe_coerce_arithmetic('71', 365)
+    (71, 365)
+    >>> _maybe_coerce_arithmetic(365, '71')
+    (365, 71)
+    >>> _maybe_coerce_arithmetic('3.14', 2)
+    (3.14, 2)
+    >>> _maybe_coerce_arithmetic('a', 'b')
+    ('a', 'b')
+    >>> _maybe_coerce_arithmetic(2, 'abc')
+    (2, 'abc')
+    >>> _maybe_coerce_arithmetic(True, '1')
+    (True, '1')
+    """
+    if isinstance(left, str) and isinstance(right, int | float) and not isinstance(right, bool):
+        coerced = _coerce_like(left, right)
+        if coerced is not None:
+            return coerced, right
+    elif isinstance(right, str) and isinstance(left, int | float) and not isinstance(left, bool):
+        coerced = _coerce_like(right, left)
+        if coerced is not None:
+            return left, coerced
+    return left, right
+
+
+def _warn_non_numeric(op, left: Any, right: Any) -> None:  # noqa: ANN001, ANN401
+    """Log that an operator got a non-numeric operand and is returning None."""
+    logger.warning(f"Non-numeric operand in {op.__name__}: {left!r}, {right!r}; returning None")
+
+
 def _null_propagating(op):  # noqa: ANN001, ANN202
     """Wrap a binary operator with null propagation and numeric coercion fallback.
 
@@ -465,7 +526,41 @@ def _null_propagating(op):  # noqa: ANN001, ANN202
         except (TypeError, ValueError):
             left_n, right_n = _try_numeric(left), _try_numeric(right)
             if left_n is None or right_n is None:
-                logger.warning(f"Non-numeric operand in {op.__name__}: {left!r}, {right!r}; returning None")
+                _warn_non_numeric(op, left, right)
+                return None
+            return op(left_n, right_n)
+
+    return wrapper
+
+
+def _null_propagating_arithmetic(op):  # noqa: ANN001, ANN202
+    """Wrap an arithmetic operator with null propagation and numeric-string coercion.
+
+    A number paired with a string is always a numeric context: the string is
+    coerced to a number, or the result is None (with a warning) when it is not
+    numeric-looking. Crucially this never falls through to Python's string
+    semantics -- ``"71" * 365`` computes ``25915`` and ``"abc" * 10`` returns
+    None, rather than repeating the string (see linkml/linkml-map#285).
+
+    Two strings keep native semantics, so ``"a" + "b"`` still concatenates; if the
+    native op then fails (e.g. ``"a" - "b"``), numeric coercion is retried.
+    """
+
+    def wrapper(left: Any, right: Any) -> Any:  # noqa: ANN401
+        if left is None or right is None:
+            return None
+        left, right = _maybe_coerce_arithmetic(left, right)
+        # After coercion, a lone string opposite a number is non-numeric: treat it
+        # as a failed numeric op rather than letting ``*`` repeat the string.
+        if isinstance(left, str) != isinstance(right, str):
+            _warn_non_numeric(op, left, right)
+            return None
+        try:
+            return op(left, right)
+        except (TypeError, ValueError):
+            left_n, right_n = _try_numeric(left), _try_numeric(right)
+            if left_n is None or right_n is None:
+                _warn_non_numeric(op, left, right)
                 return None
             return op(left_n, right_n)
 
@@ -566,7 +661,7 @@ class LinkMLEvaluator(EvalWithCompoundTypes):
             ast.BitOr,
             ast.BitAnd,
         ):
-            self.operators[op_type] = _null_propagating(self.operators[op_type])
+            self.operators[op_type] = _null_propagating_arithmetic(self.operators[op_type])
         for op_type in (ast.USub, ast.UAdd, ast.Invert):
             self.operators[op_type] = _null_propagating_unary(self.operators[op_type])
 

--- a/src/linkml_map/utils/eval_utils.py
+++ b/src/linkml_map/utils/eval_utils.py
@@ -501,7 +501,7 @@ def _maybe_coerce_arithmetic(left: Any, right: Any) -> tuple[Any, Any]:  # noqa:
 
 def _warn_non_numeric(op, left: Any, right: Any) -> None:  # noqa: ANN001, ANN401
     """Log that an operator got a non-numeric operand and is returning None."""
-    logger.warning(f"Non-numeric operand in {op.__name__}: {left!r}, {right!r}; returning None")
+    logger.warning("Non-numeric operand in %s: %r, %r; returning None", op.__name__, left, right)
 
 
 def _null_propagating(op):  # noqa: ANN001, ANN202

--- a/tests/test_utils/test_eval_utils.py
+++ b/tests/test_utils/test_eval_utils.py
@@ -308,6 +308,9 @@ def test_arithmetic_multiply_numeric_string_is_numeric() -> None:
     assert eval_expr("{col} * 365", col=71) == 25915
     assert eval_expr("({col} * 365) + 1825", col="71") == 27740
     assert eval_expr("{col} * 365", col="3.14") == pytest.approx(1146.1)
+    # int * str is native repetition too, so the RHS path needs the same guard.
+    assert eval_expr("365 * {col}", col="71") == 25915
+    assert eval_expr("365 * {col}", col="3.14") == pytest.approx(1146.1)
 
 
 def test_arithmetic_multiply_string_and_number_preserves_concatenation_and_lists() -> None:

--- a/tests/test_utils/test_eval_utils.py
+++ b/tests/test_utils/test_eval_utils.py
@@ -297,11 +297,37 @@ def test_arithmetic_coerces_numeric_strings() -> None:
     assert eval_expr("{x} / 100.0 * {y}", x="200", y="50") == 100.0
 
 
+def test_arithmetic_multiply_numeric_string_is_numeric() -> None:
+    """``*`` on a numeric string is arithmetic, not Python string repetition (#285).
+
+    A numeric-looking column typed ``string`` (so the loader leaves it a string)
+    must not turn ``{col} * 365`` into the string repeated 365 times. Coercion
+    preserves the other operand's type, so the result matches the int-typed path.
+    """
+    assert eval_expr("{col} * 365", col="71") == 25915
+    assert eval_expr("{col} * 365", col=71) == 25915
+    assert eval_expr("({col} * 365) + 1825", col="71") == 27740
+    assert eval_expr("{col} * 365", col="3.14") == pytest.approx(1146.1)
+
+
+def test_arithmetic_multiply_string_and_number_preserves_concatenation_and_lists() -> None:
+    """``*`` stays numeric for number/string pairs but keeps genuine string/list semantics."""
+    # Two strings still concatenate with + (documented behavior), not coerced.
+    assert eval_expr("{a} + {b}", a="foo", b="bar") == "foobar"
+    assert eval_expr("{a} + {b}", a="71", b="365") == "71365"
+    # A list times a number is genuine repetition/distribution, left untouched.
+    assert eval_expr("x * 3", x=[1, 2]) == [1, 2, 1, 2, 1, 2]
+
+
 def test_arithmetic_non_numeric_string_returns_none() -> None:
     """Non-numeric strings in arithmetic return None with a warning instead of crashing."""
     assert eval_expr("x / y", x="100", y="abc") is None
     assert eval_expr("x * y", x="abc", y="10") is None
     assert eval_expr("x + y", x="abc", y=10) is None
+    # ``*`` is the trap: str * int succeeds natively as repetition, so a
+    # non-numeric string times a number must be forced to None, not "abcabc...".
+    assert eval_expr("x * y", x="abc", y=10) is None
+    assert eval_expr("x * y", x=10, y="abc") is None
 
 
 def test_null_in_function_call() -> None:


### PR DESCRIPTION
## Problem

Since ff846709, TSV/CSV loading only coerces columns the schema types as numeric; a numeric-looking column typed `string` (e.g. schema-automator inferring `string` for a sparse column) reaches an `expr` as a string. `*` is the trap — `str * int` is valid Python (string repetition), so it succeeds natively and never reaches the evaluator's numeric fallback:

- `{col} * 365` on `"71"` → the string `"71"` repeated 365 times, not `25915`
- `({col} * 365) + 1825` → `inf`

The output is silently corrupt, with no error raised. (`-`, `/`, etc. already worked, since they raise on a string operand and fall through to numeric coercion.)

## Fix

`_null_propagating_arithmetic` now coerces a numeric-string operand to a number before applying the operator, preferring the *other* operand's type so `"71" * 365 == 25915` — matching the result you'd get if the column were typed `integer`.

A number paired with a **non-numeric** string (e.g. `"abc" * 10`) now returns `None` with a warning instead of repeating the string, making `*` consistent with the other arithmetic operators. Two strings are left untouched, so `"a" + "b"` still concatenates and `[1, 2] * 3` still distributes.

## Tests

Added coverage for numeric-string arithmetic, concatenation/list preservation, and the non-numeric `*` → `None` case, plus doctests on the new helpers.

Closes #285