### PR TITLE
Document that the personinfo_basic example needs --unrestricted-eval

### DIFF
--- a/tests/input/examples/personinfo_basic/transform/personinfo-to-agent.transform.yaml
+++ b/tests/input/examples/personinfo_basic/transform/personinfo-to-agent.transform.yaml
@@ -1,3 +1,6 @@
+# Run this spec with `linkml-map map-data --unrestricted-eval`. Several Agent
+# derivations use `src.` accessors and comprehensions, which safe mode does not
+# provide; without the flag `src` resolves to None and the derivation fails.
 id: https://w3id.org/linkml/map/example/personinfo-to-agent.transform.yaml
 title: PersonInfo to Agent example transformation
 version: 0.1

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -11,11 +11,13 @@ from click.testing import CliRunner, Result
 from linkml_runtime import SchemaView
 
 from linkml_map.cli.cli import dump_output, main
+from linkml_map.transformer.errors import TransformationError
 from tests import (
     DENORM_SPECIFICATION,
     FLATTENING_DATA,
     NORM_SCHEMA,
     PERSONINFO_CONTAINER_DATA,
+    PERSONINFO_CONTAINER_TGT_DATA,
     PERSONINFO_DERIVED,
     PERSONINFO_SRC_SCHEMA,
     PERSONINFO_TR,
@@ -147,21 +149,47 @@ def test_derive_schema(runner: CliRunner, output: str | None, tmp_path: Generato
     assert "Agent" in sv.all_classes()
 
 
-def test_map_data(runner: CliRunner) -> None:
-    cmd = [
+def _map_data_cmd(*extra_args: str) -> list[str]:
+    """Build a ``map-data`` invocation for the personinfo_basic example."""
+    return [
         "map-data",
-        "--unrestricted-eval",
+        *extra_args,
         "-T",
         str(PERSONINFO_TR),
         "-s",
         str(PERSONINFO_SRC_SCHEMA),
         str(PERSONINFO_CONTAINER_DATA),
     ]
-    result = runner.invoke(main, cmd)
+
+
+def _drop_nulls(obj: object) -> object:
+    """Recursively strip ``None``-valued keys, which the CLI omits from its output."""
+    if isinstance(obj, dict):
+        return {k: _drop_nulls(v) for k, v in obj.items() if v is not None}
+    if isinstance(obj, list):
+        return [_drop_nulls(v) for v in obj]
+    return obj
+
+
+def test_map_data(runner: CliRunner) -> None:
+    """``map-data --unrestricted-eval`` reproduces the committed example output."""
+    result = runner.invoke(main, _map_data_cmd("--unrestricted-eval"))
     assert result.exit_code == 0
-    out = result.stdout
-    tr_data = yaml.safe_load(out)
-    assert tr_data["agents"][0]["label"] == "fred bloggs"
+    with PERSONINFO_CONTAINER_TGT_DATA.open() as fh:
+        expected = yaml.safe_load(fh)
+    assert yaml.safe_load(result.stdout) == _drop_nulls(expected)
+
+
+def test_map_data_without_unrestricted_eval_fails(runner: CliRunner) -> None:
+    """The example's ``src.`` expressions need unrestricted eval; safe mode must not
+    silently emit partial data.
+
+    See https://github.com/linkml/linkml-map/issues/270.
+    """
+    result = runner.invoke(main, _map_data_cmd())
+    assert result.exit_code != 0
+    assert isinstance(result.exception, TransformationError)
+    assert "driving_since" in str(result.exception)
 
 
 def _write_typo_spec_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:


### PR DESCRIPTION
The flagship `personinfo_basic` example fails under default `map-data` flags: its Agent derivations use `src.` accessors and comprehensions, which are unrestricted-eval features. In safe mode `src` resolves to `None` and `driving_since` dies with `'NoneType' object is not iterable`.

The docs already pass the flag (6b8d748), but the spec file gave a reader no hint, and no test covered the default CLI path — `tests/test_transformer/test_object_transformer.py:70` hardcodes `unrestricted_eval=True` in the `obj_tr` fixture, which masked it.

- Note the requirement at the top of `personinfo-to-agent.transform.yaml`.
- `test_map_data` now asserts the full committed fixture rather than a single label (the CLI omits nulls, so the comparison strips them).
- `test_map_data_without_unrestricted_eval_fails` pins the default path, so safe mode can't start silently emitting partial data.

Not doing the third item from the issue: `multi_file_transformer.py:177`'s hardcoded `unrestricted_eval=True` only ever runs specs committed to this repo, under pytest. There's no untrusted input, so a warning there would be noise.

Closes #270